### PR TITLE
Added clipboard to the AUR and updated README accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Windows:
 cmake --install .
 ```
 
+# Install from the AUR
+
+Arch-Linux users can install the [clipboard](https://aur.archlinux.org/packages/clipboard), [clipboard-bin](https://aur.archlinux.org/packages/clipboard-bin) or [clipboard-git](https://aur.archlinux.org/packages/clipboard-git) AUR package.
+
 # Painless Documentation 
 
 [Click here](https://github.com/Slackadays/Clipboard/wiki) to go the Clipboard Wiki.


### PR DESCRIPTION
Hi,

First of all, thanks for your awesome work with `clipboard`! 

I added it to the AUR ([Arch User Repository](https://wiki.archlinux.org/title/Arch_User_Repository)), so Arch Linux users (and Arch Linux based distros users in general) can benefit from an easy/automated installation (and update) process for `clipboard`. 
I hope you're fine with that! :)

You can review the `clipboard` AUR packages I made here:
- [clipboard](https://aur.archlinux.org/packages/clipboard) --> Regular package compiled from the latest GitHub release.
PKGBUILD available [here](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=clipboard).
- [clipboard-bin](https://aur.archlinux.org/packages/clipboard-bin) --> Binary package installed from the pre-compiled binary archive of the latest GitHub release. 
PKGBUILD available [here](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=clipboard-bin).
- [clipboard-git](https://aur.archlinux.org/packages/clipboard-git) --> VCS package compiled from the latest commit of the GitHub repo. 
PKGBUILD available [here](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=clipboard-git).

I'm obviously down to maintain those packages on the AUR for all the future updates `clipboard` will get!

Additionally, I edited the README to let people know that `clipboard` is now available on the AUR as well (hence this PR).
Even though those `clipboard` AUR packages are basically just an automated way to grab and compile `clipboard`'s sources for Arch users, I would totally understand if you don't want to consider them as an official way of installing `clipboard`.
If that's the case, don't hesitate to ask me to tag them as such in the README, or even reject my PR if you don't want to "promote" them.

Don't hesitate to reach me if you need more info.
Once again, thanks for your awesome work!

