### PR TITLE
add makefile to make clipboard installation easy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+install-linux:
+	@printf "=> Clipboard Makefile v1.0.0\n"
+	@printf "=> Made by gentoo-btw\n"
+	@test -f /usr/bin/cmake && printf "=> Found cmake at /usr/bin/cmake\n"
+	@test -f /usr/bin/cmake || printf "=> cmake not found. please install cmake.\n"
+	@read -p "=> You are about to install Clipboard. Are you sure you want to do this?. If you do. Press ENTER to install Clipboard."
+	@printf "=> cmake Clipboard/src"
+	@cmake Clipboard/src
+	@printf "=> cmake --build .\n"
+	@cmake --build .
+	@printf "=> sudo cmake --install .\n"
+	@cmake --install .
+	@printf "=> Thank you for installing Clipboard.\n"
+
+install-win:
+	@printf "=> Clipboard Makefile v1.0.0\n"
+	@printf "=> Made by gentoo-btw\n"
+	@test -f /usr/bin/cmake && printf "=> Found cmake at /usr/bin/cmake\n"
+	@test -f /usr/bin/cmake || printf "=> cmake not found. please install cmake.\n"
+	@read -p "=> You are about to install Clipboard. Are you sure you want to do this?. If you do. Press ENTER to install Clipboard."
+	@printf "=> cmake Clipboard/src\n"
+	@cmake Clipboard/src
+	@printf "=> cmake --build .\n"
+	@cmake --build .
+	@printf "=> cmake --install .\n"
+	@cmake --install .
+	@printf "=> Thank you for installing Clipboard.\n"
+
+install-bsd:
+	@printf "=> Clipboard Makefile v1.0.0\n"
+	@printf "=> Made by gentoo-btw\n"
+	@test -f /usr/bin/cmake && printf "=> Found cmake at /usr/bin/cmake\n"
+	@test -f /usr/bin/cmake || printf "=> cmake not found. please install cmake.\n"
+	@read -p "=> You are about to install Clipboard. Are you sure you want to do this?. If you do. Press ENTER to install Clipboard."
+	@printf "=> cmake Clipboard/src\n"
+	@cmake Clipboard/src
+	@printf "=> cmake --build .\n"
+	@cmake --build .
+	@printf "=> doas cmake --install .\n"
+	@doas cmake --install .
+	@printf "=> Thank you for installing Clipboard.\n"

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,6 @@ install-linux:
 install-win:
 	@printf "=> Clipboard Makefile v1.0.0\n"
 	@printf "=> Made by gentoo-btw\n"
-	@test -f /usr/bin/cmake && printf "=> Found cmake at /usr/bin/cmake\n"
-	@test -f /usr/bin/cmake || printf "=> cmake not found. please install cmake.\n"
 	@read -p "=> You are about to install Clipboard. Are you sure you want to do this?. If you do. Press ENTER to install Clipboard."
 	@printf "=> cmake Clipboard/src\n"
 	@cmake Clipboard/src

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 install-linux:
 	@printf "=> Clipboard Makefile v1.0.0\n"
 	@printf "=> Made by gentoo-btw\n"
-	@test -f /usr/bin/cmake && printf "=> Found cmake at /usr/bin/cmake\n"
-	@test -f /usr/bin/cmake || printf "=> cmake not found. please install cmake.\n"
 	@read -p "=> You are about to install Clipboard. Are you sure you want to do this?. If you do. Press ENTER to install Clipboard."
 	@printf "=> cmake Clipboard/src"
 	@cmake Clipboard/src
@@ -24,11 +22,9 @@ install-win:
 	@cmake --install .
 	@printf "=> Thank you for installing Clipboard.\n"
 
-install-bsd:
+install-openbsd:
 	@printf "=> Clipboard Makefile v1.0.0\n"
 	@printf "=> Made by gentoo-btw\n"
-	@test -f /usr/bin/cmake && printf "=> Found cmake at /usr/bin/cmake\n"
-	@test -f /usr/bin/cmake || printf "=> cmake not found. please install cmake.\n"
 	@read -p "=> You are about to install Clipboard. Are you sure you want to do this?. If you do. Press ENTER to install Clipboard."
 	@printf "=> cmake Clipboard/src\n"
 	@cmake Clipboard/src

--- a/README.md
+++ b/README.md
@@ -59,7 +59,29 @@ or
 ## Clear
 `clipboard clear`
 
-# Quick Installation
+# Installation using make
+## Clone
+```
+git clone https://github.com/slackadays/Clipboard
+```
+
+## Run make
+
+For linux users. run `make install-linux` (without sudo)
+```
+make install-linux
+```
+
+For Windows users. run `make install-win`
+```
+make install-win
+```
+
+For BSD users. run `make install-bsd`
+```
+make install-bsd
+```
+# Manual Installation 
 ## Clone
 ```
 git clone https://github.com/slackadays/Clipboard

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ For Windows users. run `make install-win`
 make install-win
 ```
 
-For BSD users. run `make install-bsd`
+For OpenBSD users. run `make install-bsd`
 ```
-make install-bsd
+make install-openbsd
 ```
 # Manual Installation 
 ## Clone


### PR DESCRIPTION
you can install clipboard by compiling, installing it yourself. but why not add a makefile to make the install process easier? (for users who doesn't wanna manually install clipboard)