### PR TITLE
Improve cross-compilation support for Windows

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -31,9 +31,11 @@
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <io.h>
+#ifndef NOMINMAX
 #define NOMINMAX
-#include <Windows.h>
-#include <Shlobj.h>
+#endif
+#include <windows.h>
+#include <shlobj.h>
 #define isatty _isatty
 #define fileno _fileno
 #else


### PR DESCRIPTION
While there is no canonical capitalization for "windows.h" it has always been all lowercase on implementations using case-sensitive file systems, e.g. a cross-compiler running on Linux. Same goes for most (but not all) other headers including "shlobj.h".

Ideally a configuration macro such as NOMINIMAX is defined before any includes. Since it's so critical, libstdc++ on Windows automatically defines it in its own headers if included first, which results in a warning about a macro redefinition when compiling with GCC. Either move the _WIN32 section before other includes, or as in this commit, detect if it happened and avoid the redefinition.