### PR TITLE
Fix up data races, a race condition, and a deadlock

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -445,7 +445,7 @@ void setupIndicator() {
         }
     } else if ((action == Action::PipeIn || action == Action::PipeOut) && stderr_is_tty) {
         for (int i = 0; spinner_state == SpinnerState::Active; i == 9 ? i = 0 : i++) {
-            output_length = fprintf(stderr, replaceColors(working_message).data(), doing_action[action].data(), (int)bytes_success, "B", spinner_steps.at(i).data());
+            output_length = fprintf(stderr, replaceColors(working_message).data(), doing_action[action].data(), static_cast<int>(bytes_success), "B", spinner_steps.at(i).data());
             fflush(stderr);
             cv.wait_for(lock, std::chrono::milliseconds(50), [&]{ return spinner_state != SpinnerState::Active; });
         }
@@ -796,7 +796,7 @@ void showFailures() {
 
 void showSuccesses() {
     if (action == Action::PipeIn || action == Action::PipeOut && stderr_is_tty) {
-        fprintf(stderr, replaceColors(pipe_success_message).data(), did_action[action].data(), (int)bytes_success);
+        fprintf(stderr, replaceColors(pipe_success_message).data(), did_action[action].data(), static_cast<int>(bytes_success));
         return;
     }
     if ((files_success == 1 && directories_success == 0) || (files_success == 0 && directories_success == 1)) {
@@ -807,11 +807,11 @@ void showSuccesses() {
         }
     } else {
         if ((files_success > 1) && (directories_success == 0)) {
-            printf(replaceColors(multiple_files_success_message).data(), did_action[action].data(), (int)files_success);
+            printf(replaceColors(multiple_files_success_message).data(), did_action[action].data(), static_cast<int>(files_success));
         } else if ((files_success == 0) && (directories_success > 1)) {
-            printf(replaceColors(multiple_directories_success_message).data(), did_action[action].data(), (int)directories_success);
+            printf(replaceColors(multiple_directories_success_message).data(), did_action[action].data(), static_cast<int>(directories_success));
         } else if ((files_success >= 1) && (directories_success >= 1)) {
-            printf(replaceColors(multiple_files_directories_success_message).data(), did_action[action].data(), (int)files_success, (int)directories_success);
+            printf(replaceColors(multiple_files_directories_success_message).data(), did_action[action].data(), static_cast<int>(files_success), static_cast<int>(directories_success));
         }
     }
 }

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -71,13 +71,29 @@ void forceClearTempDirectory() {
     }
 }
 
+bool cancelIndicator() {
+    return spinner_state.exchange(SpinnerState::Cancel) == SpinnerState::Active;
+}
+
+bool stopIndicator() {
+    SpinnerState expect = SpinnerState::Active;
+    if (!spinner_state.compare_exchange_strong(expect, SpinnerState::Done)) {
+        return false;
+    }
+    cv.notify_one();
+    indicator.join();
+    return true;
+}
+
 void setupSignals() {
     signal(SIGINT, [](int dummy) {
-        indicator.request_stop();
-        fprintf(stderr, "\r%*s\r", output_length, "");
-        fprintf(stderr, replaceColors(cancelled_message).data(), actions[action].data());
-        fflush(stderr);
-        exit(1);
+        if (!cancelIndicator()) {
+            // Indicator thread is not currently running. TODO: Write an
+            // unbuffered newline, and maybe a cancelation message, directly to
+            // standard error. Note: There is no standard C++ interface for
+            // this, so this requires OS call.
+            _exit(1);
+        }
     });
 }
 
@@ -414,23 +430,24 @@ void checkForNoItems() {
     }
 }
 
-void setupIndicator(std::stop_token st) {
+void setupIndicator() {
     std::unique_lock<std::mutex> lock(m);
+    int output_length = 0;
     const std::array<std::string_view, 10> spinner_steps{"━       ", "━━      ", " ━━     ", "  ━━    ", "   ━━   ", "    ━━  ", "     ━━ ", "      ━━", "       ━", "        "};
     static unsigned int percent_done = 0;
     if ((action == Action::Cut || action == Action::Copy) && stderr_is_tty) {
         static unsigned long items_size = items.size();
-        for (int i = 0; !st.stop_requested(); i == 9 ? i = 0 : i++) {
+        for (int i = 0; spinner_state == SpinnerState::Active; i == 9 ? i = 0 : i++) {
             percent_done = ((files_success + directories_success + failedItems.size()) * 100) / items_size;
             output_length = fprintf(stderr, replaceColors(working_message).data(), doing_action[action].data(), percent_done, "%", spinner_steps.at(i).data());
             fflush(stderr);
-            cv.wait_for(lock, std::chrono::milliseconds(50), [&]{ return st.stop_requested(); });
+            cv.wait_for(lock, std::chrono::milliseconds(50), [&]{ return spinner_state != SpinnerState::Active; });
         }
     } else if ((action == Action::PipeIn || action == Action::PipeOut) && stderr_is_tty) {
-        for (int i = 0; !st.stop_requested(); i == 9 ? i = 0 : i++) {
+        for (int i = 0; spinner_state == SpinnerState::Active; i == 9 ? i = 0 : i++) {
             output_length = fprintf(stderr, replaceColors(working_message).data(), doing_action[action].data(), (int)bytes_success, "B", spinner_steps.at(i).data());
             fflush(stderr);
-            cv.wait_for(lock, std::chrono::milliseconds(50), [&]{ return st.stop_requested(); });
+            cv.wait_for(lock, std::chrono::milliseconds(50), [&]{ return spinner_state != SpinnerState::Active; });
         }
     } else if (action == Action::Paste && stderr_is_tty) {
         static unsigned long items_size = 0;
@@ -442,16 +459,36 @@ void setupIndicator(std::stop_token st) {
                 items_size = 1;
             }
         }
-        for (int i = 0; !st.stop_requested(); i == 9 ? i = 0 : i++) {
+        for (int i = 0; spinner_state == SpinnerState::Active; i == 9 ? i = 0 : i++) {
             percent_done = ((files_success + directories_success + failedItems.size()) * 100) / items_size;
             output_length = fprintf(stderr, replaceColors(working_message).data(), doing_action[action].data(), percent_done, "%", spinner_steps.at(i).data());
             fflush(stderr);
-            cv.wait_for(lock, std::chrono::milliseconds(50), [&]{ return st.stop_requested(); });
+            cv.wait_for(lock, std::chrono::milliseconds(50), [&]{ return spinner_state != SpinnerState::Active; });
         }
     } else if (stderr_is_tty) {
-        output_length = fprintf(stderr, replaceColors(working_message).data(), doing_action[action].data(), 0, "%", "");
-        fflush(stderr);
+        while (spinner_state == SpinnerState::Active) {
+            output_length = fprintf(stderr, replaceColors(working_message).data(), doing_action[action].data(), 0, "%", "");
+            fflush(stderr);
+            cv.wait_for(lock, std::chrono::milliseconds(50), [&]{ return spinner_state != SpinnerState::Active; });
+        }
     }
+    if (stderr_is_tty) {
+        fprintf(stderr, "\r%*s\r", output_length, "");
+    }
+    if (spinner_state == SpinnerState::Cancel) {
+        fprintf(stderr, replaceColors(cancelled_message).data(), actions[action].data());
+        fflush(stderr);
+        _exit(1);
+    }
+    fflush(stderr);
+}
+
+void startIndicator()
+{
+    // If cancelled, leave cancelled
+    SpinnerState expect = SpinnerState::Done;
+    spinner_state.compare_exchange_strong(expect, SpinnerState::Active);
+    indicator = std::thread(setupIndicator);
 }
 
 void deduplicateItems() {
@@ -489,9 +526,8 @@ void checkItemSize() {
     if (action == Action::Cut || action == Action::Copy) {
         total_item_size = calculateTotalItemSize();
         if (total_item_size > (space_available / 2)) {
-            printf(replaceColors(not_enough_storage_message).data(), total_item_size / 1024.0, space_available / 1024.0);
-            indicator.request_stop();
-            cv.notify_one();
+            stopIndicator();
+            fprintf(stderr, replaceColors(not_enough_storage_message).data(), total_item_size / 1024.0, space_available / 1024.0);
             exit(1);
         }
     }
@@ -628,9 +664,9 @@ void pasteFiles() {
                     case -1:
                     case 0:
                     case 1:
-                        indicator.request_stop();
+                        stopIndicator();
                         user_decision = getUserDecision(f.path().filename().string());
-                        indicator = std::jthread(setupIndicator);
+                        startIndicator();
                         break;
                     case 2:
                         pasteItem();
@@ -804,7 +840,7 @@ int main(int argc, char *argv[]) {
 
         checkForNoItems();
 
-        indicator = std::jthread(setupIndicator);
+        startIndicator();
 
         deduplicateItems();
 
@@ -818,21 +854,15 @@ int main(int argc, char *argv[]) {
             updateGUIClipboard();
         }
 
-        indicator.request_stop();
-        cv.notify_one();
-
-        if (stderr_is_tty) {
-            fprintf(stderr, "\r%*s\r", output_length, "");
-            fflush(stderr);
-        }
+        stopIndicator();
 
         showFailures();
 
         showSuccesses();
     } catch (const std::exception& e) {
-        fprintf(stderr, replaceColors(internal_error_message).data(), e.what());
-        indicator.request_stop();
-        cv.notify_one();
+        if (stopIndicator()) {
+            fprintf(stderr, replaceColors(internal_error_message).data(), e.what());
+        }
         exit(1);
     }
     return 0;

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -428,7 +428,7 @@ void setupIndicator(std::stop_token st) {
         }
     } else if ((action == Action::PipeIn || action == Action::PipeOut) && stderr_is_tty) {
         for (int i = 0; !st.stop_requested(); i == 9 ? i = 0 : i++) {
-            output_length = fprintf(stderr, replaceColors(working_message).data(), doing_action[action].data(), bytes_success, "B", spinner_steps.at(i).data());
+            output_length = fprintf(stderr, replaceColors(working_message).data(), doing_action[action].data(), (int)bytes_success, "B", spinner_steps.at(i).data());
             fflush(stderr);
             cv.wait_for(lock, std::chrono::milliseconds(50), [&]{ return st.stop_requested(); });
         }
@@ -760,7 +760,7 @@ void showFailures() {
 
 void showSuccesses() {
     if (action == Action::PipeIn || action == Action::PipeOut && stderr_is_tty) {
-        fprintf(stderr, replaceColors(pipe_success_message).data(), did_action[action].data(), bytes_success);
+        fprintf(stderr, replaceColors(pipe_success_message).data(), did_action[action].data(), (int)bytes_success);
         return;
     }
     if ((files_success == 1 && directories_success == 0) || (files_success == 0 && directories_success == 1)) {
@@ -771,11 +771,11 @@ void showSuccesses() {
         }
     } else {
         if ((files_success > 1) && (directories_success == 0)) {
-            printf(replaceColors(multiple_files_success_message).data(), did_action[action].data(), files_success);
+            printf(replaceColors(multiple_files_success_message).data(), did_action[action].data(), (int)files_success);
         } else if ((files_success == 0) && (directories_success > 1)) {
-            printf(replaceColors(multiple_directories_success_message).data(), did_action[action].data(), directories_success);
+            printf(replaceColors(multiple_directories_success_message).data(), did_action[action].data(), (int)directories_success);
         } else if ((files_success >= 1) && (directories_success >= 1)) {
-            printf(replaceColors(multiple_files_directories_success_message).data(), did_action[action].data(), files_success, directories_success);
+            printf(replaceColors(multiple_files_directories_success_message).data(), did_action[action].data(), (int)files_success, (int)directories_success);
         }
     }
 }

--- a/src/clipboard.hpp
+++ b/src/clipboard.hpp
@@ -41,9 +41,9 @@ extern std::mutex m;
 extern std::jthread indicator; //If this fails to compile, then you need C++20!
 
 extern unsigned int output_length;
-extern unsigned long files_success;
-extern unsigned long directories_success;
-extern unsigned long long bytes_success;
+extern std::atomic<unsigned long> files_success;
+extern std::atomic<unsigned long> directories_success;
+extern std::atomic<unsigned long long> bytes_success;
 
 extern bool stdin_is_tty;
 extern bool stdout_is_tty;

--- a/src/clipboard.hpp
+++ b/src/clipboard.hpp
@@ -36,11 +36,13 @@ extern std::vector<fs::path> items;
 extern std::vector<std::pair<std::string, std::error_code>> failedItems;
 extern std::string clipboard_name;
 
+enum class SpinnerState : int { Done, Active, Cancel };
+
 extern std::condition_variable cv;
 extern std::mutex m;
-extern std::jthread indicator; //If this fails to compile, then you need C++20!
+extern std::atomic<SpinnerState> spinner_state;
+extern std::thread indicator;
 
-extern unsigned int output_length;
 extern std::atomic<unsigned long> files_success;
 extern std::atomic<unsigned long> directories_success;
 extern std::atomic<unsigned long long> bytes_success;
@@ -116,7 +118,10 @@ void showClipboardStatus();
 void showClipboardContents();
 void setupAction(int& argc, char *argv[]);
 void checkForNoItems();
-void setupIndicator(std::stop_token st);
+bool cancelIndicator();
+bool stopIndicator();
+void startIndicator();
+void setupIndicator();
 void deduplicateItems();
 unsigned long long calculateTotalItemSize();
 void checkItemSize();

--- a/src/variables.cpp
+++ b/src/variables.cpp
@@ -40,9 +40,9 @@ std::mutex m;
 std::jthread indicator; //If this fails to compile, then you need C++20!
 
 unsigned int output_length = 0;
-unsigned long files_success = 0;
-unsigned long directories_success = 0;
-unsigned long long bytes_success = 0;
+std::atomic<unsigned long> files_success = 0;
+std::atomic<unsigned long> directories_success = 0;
+std::atomic<unsigned long long> bytes_success = 0;
 
 bool stdin_is_tty = true;
 bool stdout_is_tty = true;

--- a/src/variables.cpp
+++ b/src/variables.cpp
@@ -37,9 +37,9 @@ std::string clipboard_name = "0";
 
 std::condition_variable cv;
 std::mutex m;
-std::jthread indicator; //If this fails to compile, then you need C++20!
+std::atomic<SpinnerState> spinner_state = SpinnerState::Done;
+std::thread indicator;
 
-unsigned int output_length = 0;
 std::atomic<unsigned long> files_success = 0;
 std::atomic<unsigned long> directories_success = 0;
 std::atomic<unsigned long long> bytes_success = 0;


### PR DESCRIPTION
Each of the issues addressed are caught by ThreadSanitizer (`-fsanitize=thread`), which is initially how I noticed them. The second commit is a really tricky interaction between threads, signals, and exceptions (IMHO, one of many reasons to just turn off exceptions). It started simple, but grew more complex as I kept running into edge cases. It doesn't perfectly capture the original intention since that's probably impossible — a SIGINT is just fundamentally racy, and a signal handler cannot accomplish much on its own — but I tried to get it as close as I could without going outside the C++ standard library.