### PR TITLE
Implement file copies and large text copies for X11

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -206,15 +206,60 @@ void createTempDirectory() {
     fs::create_directories(persistent_filepath);
 }
 
+void syncWithGUIClipboard(std::string const& text) {
+    forceClearTempDirectory();
+    std::ofstream output(main_filepath / pipe_file);
+    output << text;
+}
+
+void syncWithGUIClipboard(ClipboardPaths const& clipboard) {
+    // Only clear the temp directory if all files in the clipboard are outside the temp directory
+    // This avoids the situation where we delete the very files we're trying to copy
+    auto allOutsideFilepath = std::all_of(clipboard.paths().begin(), clipboard.paths().end(), [](auto& path) {
+        auto relative = fs::relative(path, main_filepath);
+        auto firstElement = *(relative.begin());
+        return firstElement == fs::path("..");
+    });
+
+    if (allOutsideFilepath) {
+        forceClearTempDirectory();
+    }
+
+    for (auto&& path : clipboard.paths()) {
+        if (!fs::exists(path)) {
+            continue;
+        }
+
+        auto target = main_filepath / path.filename();
+        if (fs::exists(target) && fs::equivalent(path, target)) {
+            continue;
+        }
+
+        try {
+            fs::copy(path, target, opts | fs::copy_options::create_hard_links);
+        } catch (const fs::filesystem_error& e) {
+            try {
+                fs::copy(path, target, opts);
+            } catch (const fs::filesystem_error& e) {
+                // Give up
+            }
+        }
+    }
+
+    if (clipboard.action() == ClipboardPathsAction::Cut) {
+        std::ofstream originalFiles { original_files_path };
+        for (auto&& path : clipboard.paths()) {
+            originalFiles << path.string() << std::endl;
+        }
+    }
+}
+
 void syncWithGUIClipboard() { 
     if (clipboard_name == default_clipboard_name) { //also check if the system clipboard is newer than main_filepath (check the last write time), and if it is newer, write the contents of the system clipboard to main_filepath
+        ClipboardContent guiClipboard;
+
         #if defined(X11_AVAILABLE)
-        /*auto text = getX11Clipboard();
-        if (text.has_value()) {
-            forceClearTempDirectory();
-            std::ofstream file(main_filepath / pipe_file);
-            file << *text;
-        }*/
+        guiClipboard = getX11Clipboard();
         #endif
 
         #if defined(WAYLAND_AVAILABLE)
@@ -226,6 +271,13 @@ void syncWithGUIClipboard() {
         #elif defined(__APPLE__)
 
         #endif
+
+        if (guiClipboard.type() == ClipboardContentType::Text) {
+            syncWithGUIClipboard(guiClipboard.text());
+
+        } else if (guiClipboard.type() == ClipboardContentType::Paths) {
+            syncWithGUIClipboard(guiClipboard.paths());
+        }
     }
 }
 

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -267,7 +267,7 @@ void syncWithGUIClipboard() {
         #endif
 
         #if defined(_WIN32) || defined(_WIN64)
-        syncWithWindowsClipboard();
+        guiClipboard = syncWithWindowsClipboard();
         #elif defined(__APPLE__)
 
         #endif

--- a/src/clipboard.hpp
+++ b/src/clipboard.hpp
@@ -22,6 +22,8 @@
 #include <condition_variable>
 #include <mutex>
 
+#include "gui.hpp"
+
 namespace fs = std::filesystem;
 
 extern bool use_perma_clip;
@@ -113,6 +115,8 @@ void setupItems(int& argc, char *argv[]);
 void setClipboardName(int& argc, char *argv[]);
 void setupVariables(int& argc, char *argv[]);
 void createTempDirectory();
+void syncWithGUIClipboard(std::string const& text);
+void syncWithGUIClipboard(ClipboardPaths const& clipboard);
 void syncWithGUIClipboard();
 void showClipboardStatus();
 void showClipboardContents();

--- a/src/gui.hpp
+++ b/src/gui.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <variant>
+#include <string>
+#include <filesystem>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+enum class ClipboardPathsAction {
+    Copy,
+    Cut
+};
+
+class ClipboardPaths {
+private:
+    ClipboardPathsAction m_action;
+    std::vector<fs::path> m_paths;
+
+public:
+    ClipboardPaths(ClipboardPathsAction action, std::vector<fs::path>&& paths)
+        : m_action(action), m_paths(paths) { }
+
+    [[nodiscard]] inline ClipboardPathsAction action() const { return m_action; }
+    [[nodiscard]] inline std::vector<fs::path> const& paths() const { return m_paths; }
+};
+
+enum class ClipboardContentType {
+    Empty,
+    Text,
+    Paths
+};
+
+class ClipboardContent {
+private:
+    ClipboardContentType m_type;
+    std::variant<std::nullptr_t, std::string, ClipboardPaths> m_data;
+
+public:
+    ClipboardContent() : m_type(ClipboardContentType::Empty), m_data(nullptr) { }
+    ClipboardContent(std::string&& text) : m_type(ClipboardContentType::Text), m_data(std::move(text)) { }
+    ClipboardContent(ClipboardPaths&& paths) : m_type(ClipboardContentType::Paths), m_data(std::move(paths)) { }
+
+    [[nodiscard]] inline ClipboardContentType type() const { return m_type; }
+    [[nodiscard]] inline std::string const& text() { return std::get<std::string>(m_data); }
+    [[nodiscard]] inline ClipboardPaths const& paths() { return std::get<ClipboardPaths>(m_data); }
+};

--- a/src/gui.hpp
+++ b/src/gui.hpp
@@ -40,6 +40,8 @@ public:
     ClipboardContent() : m_type(ClipboardContentType::Empty), m_data(nullptr) { }
     ClipboardContent(std::string&& text) : m_type(ClipboardContentType::Text), m_data(std::move(text)) { }
     ClipboardContent(ClipboardPaths&& paths) : m_type(ClipboardContentType::Paths), m_data(std::move(paths)) { }
+    ClipboardContent(ClipboardPathsAction action, std::vector<fs::path>&& paths)
+        : ClipboardContent(ClipboardPaths(action, std::move(paths))) { }
 
     [[nodiscard]] inline ClipboardContentType type() const { return m_type; }
     [[nodiscard]] inline std::string const& text() { return std::get<std::string>(m_data); }

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -16,6 +16,7 @@
 #include <vector>
 #include <string_view>
 #include "clipboard.hpp"
+#include "gui.hpp"
 
 namespace fs = std::filesystem;
 
@@ -41,9 +42,9 @@ void decodeWindowsDropfilesPaths(void* filesList, std::vector<fs::path>& paths) 
 }
 
 void onWindowsError(const std::string_view function);
-void getWindowsClipboardDataFiles(void* clipboardPointer);
-void getWindowsClipboardDataPipe(void* clipboardPointer);
+std::vector<fs::path> getWindowsClipboardDataFiles(void* clipboardPointer);
+std::string getWindowsClipboardDataPipe(void* clipboardPointer);
 void setWindowsClipboardDataPipe();
 void setWindowsClipboardDataFiles();
-void syncWithWindowsClipboard();
+ClipboardContent syncWithWindowsClipboard();
 void updateWindowsClipboard();

--- a/src/x11.hpp
+++ b/src/x11.hpp
@@ -14,7 +14,9 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 #pragma once
 
+#include "gui.hpp"
+
 #include <string>
 #include <optional>
 
-std::optional<std::string> getX11Clipboard();
+ClipboardContent getX11Clipboard();


### PR DESCRIPTION
This PR finishes the X11 copy implementation by supporting large text copies and file copies. It also unifies the Windows and X11 clipboard copy handling so they can both share the same logic (don't empty temp dir if the files being copied are inside of it, don't copy files that don't exist, etc).

Note that unlike text copying, there doesn't seem to be a clear consensus on how to store file paths in the X11 clipboard. The code here handles the two most common types I could find experimenting around: `x-special/gnome-copied-files` and `text/uri-list`. 