### PR TITLE
Implement X11 pasting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ if(WIN32)
   target_sources(clipboard PRIVATE src/windows.cpp)
 endif()
 
-if(X11_FOUND OR WAYLAND_CLIENT_FOUND)
+if(UNIX AND NOT APPLE)
   target_sources(clipboard PRIVATE src/x11_wayland.cpp)
 endif()
 

--- a/src/gui.hpp
+++ b/src/gui.hpp
@@ -33,8 +33,8 @@ private:
 
 public:
     ClipboardPaths(std::vector<fs::path>&& paths, ClipboardPathsAction action = ClipboardPathsAction::Copy)
-        : m_action(action), m_paths(paths) { }
-    ClipboardPaths(std::vector<fs::path>& paths, ClipboardPathsAction action = ClipboardPathsAction::Copy)
+        : m_action(action), m_paths(std::move(paths)) { }
+    ClipboardPaths(std::vector<fs::path> const& paths, ClipboardPathsAction action = ClipboardPathsAction::Copy)
         : m_action(action), m_paths(paths) { }
 
     [[nodiscard]] inline ClipboardPathsAction action() const { return m_action; }
@@ -54,18 +54,22 @@ private:
 
 public:
     ClipboardContent() : m_type(ClipboardContentType::Empty), m_data(nullptr) { }
-    ClipboardContent(std::string& text) : m_type(ClipboardContentType::Text), m_data(std::move(text)) { }
+
+    ClipboardContent(std::string const& text) : m_type(ClipboardContentType::Text), m_data(text) { }
     ClipboardContent(std::string&& text) : m_type(ClipboardContentType::Text), m_data(std::move(text)) { }
-    ClipboardContent(ClipboardPaths& paths) : m_type(ClipboardContentType::Paths), m_data(std::move(paths)) { }
+
+    ClipboardContent(ClipboardPaths const& paths) : m_type(ClipboardContentType::Paths), m_data(paths) { }
     ClipboardContent(ClipboardPaths&& paths) : m_type(ClipboardContentType::Paths), m_data(std::move(paths)) { }
+
     ClipboardContent(std::vector<fs::path>&& paths, ClipboardPathsAction action = ClipboardPathsAction::Copy)
         : ClipboardContent(ClipboardPaths(std::move(paths), action)) { }
+    ClipboardContent(std::vector<fs::path> const& paths, ClipboardPathsAction action = ClipboardPathsAction::Copy)
+        : ClipboardContent(ClipboardPaths(paths, action)) { }
 
     [[nodiscard]] inline ClipboardContentType type() const { return m_type; }
-    [[nodiscard]] inline std::string const& text() { return std::get<std::string>(m_data); }
-    [[nodiscard]] inline ClipboardPaths const& paths() { return std::get<ClipboardPaths>(m_data); }
+    [[nodiscard]] inline std::string const& text() const { return std::get<std::string>(m_data); }
+    [[nodiscard]] inline ClipboardPaths const& paths() const { return std::get<ClipboardPaths>(m_data); }
 };
 
-void readDataFromGUIClipboard(const std::string& text);
-void readDataFromGUIClipboard(const ClipboardPaths& clipboard);
-ClipboardContent getThisClipboard();
+ClipboardContent getGUIClipboard();
+void writeToGUIClipboard(ClipboardContent const& clipboard);

--- a/src/macos.cpp
+++ b/src/macos.cpp
@@ -47,7 +47,7 @@ ClipboardContent getGUIClipboard() {
     return ClipboardContent();
 }
 
-void writeToGUIClipboard(ClipboardContent& clipboard) {
+void writeToGUIClipboard(ClipboardContent const& clipboard) {
     if (clipboard.type() == ClipboardContentType::Text) {
         writeText(clipboard.text().c_str());
     } else if (clipboard.type() == ClipboardContentType::Paths) {

--- a/src/x11.cpp
+++ b/src/x11.cpp
@@ -26,14 +26,17 @@
 #include <ranges>
 #include <string_view>
 #include <thread>
+#include <utility>
 #include <variant>
 #include <vector>
 #include <limits>
+#include <set>
 
 #include <X11/Xlib.h>
 
 namespace chrono = std::chrono;
 namespace ranges = std::ranges;
+namespace views = std::views;
 
 using namespace std::literals;
 
@@ -44,7 +47,12 @@ constexpr auto maxEventPollBackoffTime = 500ms;
 
 constexpr auto atomClipboard = "CLIPBOARD";
 constexpr auto atomTargets = "TARGETS";
+constexpr auto atomMultiple = "MULTIPLE";
+constexpr auto atomTimestamp = "TIMESTAMP";
 constexpr auto atomIncr = "INCR";
+constexpr auto atomAtom = "ATOM";
+constexpr auto atomAtomPair = "ATOM_PAIR";
+constexpr auto atomInteger = "INTEGER";
 
 // Forward declarations
 class X11ClipboardType;
@@ -55,7 +63,12 @@ class X11PropertyFormat;
 class X11Property;
 class X11PropertyIterator;
 class X11Window;
+class X11SelectionRequest;
+class X11SelectionTransfer;
+class X11IncrTransfer;
+class X11SelectionDaemon;
 
+enum class X11ClipboardTypeOption;
 enum class X11PropertyMode;
 
 #define X_CALL(name, ...) doXCall(#name, &name, __VA_ARGS__)
@@ -68,39 +81,59 @@ X11Pointer<T> capture(T* ptr) {
     return { ptr, &XFree };
 }
 
+enum class X11ClipboardTypeOption {
+    NoOption = 0,
+    ChooseBestType = 1 << 1,
+    IncludeAction = 1 << 2,
+    EncodePaths = 1 << 3,
+};
+static X11ClipboardTypeOption operator|(X11ClipboardTypeOption const& a, X11ClipboardTypeOption const& b) {
+    return static_cast<X11ClipboardTypeOption>(static_cast<int>(a) | static_cast<int>(b));
+}
+
 class X11ClipboardType {
 private:
     unsigned int const m_priority;
     char const* const m_name;
     ClipboardContentType const m_type;
+    X11ClipboardTypeOption m_options;
 
 public:
     X11ClipboardType(
         unsigned int priority,
         char const* const name,
-        ClipboardContentType type)
+        ClipboardContentType type,
+        X11ClipboardTypeOption options)
         : m_priority(priority)
         , m_name(name)
-        , m_type(type) { }
+        , m_type(type)
+        , m_options(options) { }
 
     [[nodiscard]] inline unsigned int priority() const { return m_priority; }
     [[nodiscard]] inline char const* const name() const { return m_name; }
     [[nodiscard]] inline ClipboardContentType type() const { return m_type; }
+    [[nodiscard]] inline bool isChooseBestType() const { return (static_cast<int>(m_options) & static_cast<int>(X11ClipboardTypeOption::ChooseBestType)) != 0; }
+    [[nodiscard]] inline bool isIncludeAction() const { return (static_cast<int>(m_options) & static_cast<int>(X11ClipboardTypeOption::IncludeAction)) != 0; }
+    [[nodiscard]] inline bool isEncodePaths() const { return (static_cast<int>(m_options) & static_cast<int>(X11ClipboardTypeOption::EncodePaths)) != 0; }
+
+    bool supports(ClipboardContent const&) const;
 
 private:
     inline static std::map<std::string_view, X11ClipboardType> s_typesByName {};
-    inline static std::vector<std::pair<char const* const, ClipboardContentType>> const s_knownTypes {
-        { "x-special/gnome-copied-files", ClipboardContentType::Paths },
-        { "text/uri-list", ClipboardContentType::Paths },
-        { "text/plain;charset=utf-8", ClipboardContentType::Text },
-        { "UTF8_STRING", ClipboardContentType::Text },
-        { "text/plain", ClipboardContentType::Text },
-        { "STRING", ClipboardContentType::Text },
-        { "TEXT", ClipboardContentType::Text },
+    inline static std::vector<std::tuple<char const* const, ClipboardContentType, X11ClipboardTypeOption>> const s_knownTypes {
+        { "x-special/gnome-copied-files", ClipboardContentType::Paths, X11ClipboardTypeOption::IncludeAction | X11ClipboardTypeOption::EncodePaths },
+        { "text/uri-list", ClipboardContentType::Paths, X11ClipboardTypeOption::NoOption | X11ClipboardTypeOption::EncodePaths },
+        { "text/plain;charset=utf-8", ClipboardContentType::Text, X11ClipboardTypeOption::NoOption },
+        { "UTF8_STRING", ClipboardContentType::Text, X11ClipboardTypeOption::NoOption },
+        { "text/plain", ClipboardContentType::Text, X11ClipboardTypeOption::NoOption },
+        { "STRING", ClipboardContentType::Text, X11ClipboardTypeOption::NoOption },
+        { "TEXT", ClipboardContentType::Text, X11ClipboardTypeOption::ChooseBestType },
     };
 
     static void tryPopulateTypesByName();
 public:
+    static auto all() { return views::values(s_typesByName); }
+    static std::optional<X11ClipboardType> find(X11Atom const&);
     static std::optional<X11ClipboardType> findBest(std::vector<std::reference_wrapper<X11Atom const>> const&);
 };
 
@@ -135,6 +168,8 @@ public:
     [[nodiscard]] std::string_view name() const;
 
     bool operator==(X11Atom const& other) const;
+    bool operator==(Atom const& other) const;
+    bool operator==(std::string_view const& other) const;
 };
 
 class X11Connection {
@@ -152,6 +187,7 @@ private:
     Display* m_display;
     std::map<std::string_view const, std::shared_ptr<X11Atom>> m_atoms_by_name;
     std::map<Atom const, std::shared_ptr<X11Atom>> m_atoms_by_value;
+    std::map<Window, std::weak_ptr<X11Window>> m_externalWindows;
 
     std::optional<std::string_view> m_currentXCall;
     std::optional<X11Exception> m_pendingXCallException;
@@ -168,14 +204,20 @@ public:
     inline auto doXCall(std::string_view callName, F callLambda, Args... args);
 
     [[nodiscard]] inline Display* display() const { return m_display; }
+    [[nodiscard]] inline std::size_t maxRequestSize() const { return XMaxRequestSize(display()); }
+    [[nodiscard]] inline std::size_t maxDataSizeForIncr() const { return maxRequestSize() / 2; }
 
     X11Atom const& atom(char const*);
     X11Atom const& atom(Atom);
 
+    [[nodiscard]] XEvent nextEvent();
+    [[nodiscard]] std::optional<XEvent> checkMaskEvent(int eventMask);
     Window getSelectionOwner(X11Atom const&);
+    void sendEvent(Window, bool propagate, long eventMask, XEvent& event);
     bool isClipboardOwned();
 
     X11Window createWindow();
+    std::shared_ptr<X11Window> externalWindow(Window);
 };
 
 class X11PropertyFormat {
@@ -208,6 +250,20 @@ public:
     static X11PropertyFormat fromValue(std::size_t value) {
         return { static_cast<Value>(value) };
     }
+
+    static X11PropertyFormat fromSize(std::size_t size) {
+        if (size == sizeof(std::uint8_t)) {
+            return Format8;
+        }
+        if (size == sizeof(std::uint16_t)) {
+            return Format16;
+        }
+        if (size == sizeof(std::uint64_t)) {
+            return Format32;
+        }
+
+        throw X11Exception("Invalid format size");
+    }
 };
 
 enum class X11PropertyMode : int {
@@ -220,30 +276,17 @@ class X11Property {
 private:
     X11Atom const& m_name;
     X11Atom const& m_type;
-    X11PropertyFormat const m_format;
+    X11PropertyFormat m_format;
 
-    std::variant<std::uint8_t const*, std::unique_ptr<std::uint8_t const[]>> const m_data8;
-    std::size_t const m_size8;
+    std::variant<std::uint8_t const*, std::unique_ptr<std::uint8_t[]>> m_data8;
+    std::size_t m_size8;
 
 public:
-    X11Property(X11Atom const& name, X11Atom const& type, std::u8string_view data)
-        : m_name(name)
-        , m_type(type)
-        , m_format(X11PropertyFormat::Format8)
-        , m_data8(reinterpret_cast<uint8_t const*>(data.data()))
-        , m_size8(data.size()) {}
+    template<ranges::contiguous_range range_t, typename char_t = ranges::range_value_t<range_t>>
+    X11Property(X11Atom const& name, X11Atom const& type, range_t data, bool owned);
 
-    X11Property(
-            X11Atom const& name,
-            X11Atom const& type,
-            X11PropertyFormat format,
-            std::unique_ptr<std::uint8_t[]>&& data8,
-            std::size_t size8)
-        : m_name(name)
-        , m_type(type)
-        , m_format(format)
-        , m_data8(std::move(data8))
-        , m_size8(size8) {}
+    template<ranges::contiguous_range range_t, typename char_t = ranges::range_value_t<range_t>>
+    X11Property(X11Atom const& name, X11Atom const& type, X11PropertyFormat const&, range_t data, bool owned);
 
     [[nodiscard]] inline X11Atom const& name() const { return m_name; }
     [[nodiscard]] inline X11Atom const& type() const { return m_type; }
@@ -270,6 +313,8 @@ public:
 
     [[nodiscard]] X11PropertyIterator begin() const;
     [[nodiscard]] X11PropertyIterator end() const;
+
+    [[nodiscard]] X11Property range(std::size_t start, std::size_t end);
 };
 
 class X11PropertyIterator {
@@ -292,13 +337,18 @@ public:
     X11Window(X11Window const&) = delete;
     X11Window& operator=(X11Window const&) = delete;
 
+    X11Window(X11Window&&) = default;
+    X11Window& operator=(X11Window&&) = default;
+
 private:
-    X11Connection&  m_connection;
+    X11Connection& m_connection;
     Window m_window;
+    bool m_owned;
 
     void throwIfDestroyed() const;
 public:
     X11Window(X11Connection&, Window);
+    X11Window(X11Connection&, Window, bool owned);
     ~X11Window();
 
     [[nodiscard]] inline X11Connection& connection() const { return m_connection; }
@@ -311,23 +361,191 @@ public:
     [[nodiscard]] Time queryCurrentTime();
     [[nodiscard]] std::optional<XEvent> checkTypedWindowEvent(int eventType);
     [[nodiscard]] std::optional<XEvent> checkMaskEvent(int eventMask);
-    void changeProperty(X11PropertyMode, X11Property&);
+    void changeProperty(X11PropertyMode, X11Property const&);
     void deleteProperty(X11Atom const&);
     [[nodiscard]] X11Property getProperty(X11Atom const&, bool delet = false);
     [[nodiscard]] X11Property convertSelection(X11Atom const& selection, X11Atom const& target);
+    void setSelectionOwner(X11Atom const& selection, Time time);
+    XWindowAttributes getWindowAttributes();
+    void changeWindowAttributes(unsigned long valuemask, XSetWindowAttributes* attributes);
+    void sendEvent(bool propagate, long eventMask, XEvent& event);
 
     [[nodiscard]] std::vector<std::reference_wrapper<X11Atom const>> queryClipboardTargets();
     [[nodiscard]] X11Property convertClipboard(X11Atom const& target);
     [[nodiscard]] std::vector<char> getClipboardData(X11Atom const& target);
+    void setEventMask(long);
+    void addToEventMask(long);
+    void addPropertyChangeToEventMask();
+    void clearEventMask();
 
-    template<typename predicate_t>
+    template<std::predicate<XEvent const&> predicate_t>
     XEvent waitForEvent(int eventType, predicate_t predicate);
 
     template<typename F, typename... Args>
     inline auto doXCall(std::string_view callName, F callLambda, Args... args) {
         return connection().doXCall(callName, callLambda, args...);
     }
+
+    bool operator==(X11Window const&) const;
+    bool operator==(Window const&) const;
 };
+
+class X11SelectionRequest {
+private:
+    XSelectionRequestEvent m_event;
+    std::shared_ptr<X11Window> m_window;
+    X11Atom const& m_target;
+    X11Atom const& m_property;
+    bool m_multiple;
+
+    X11SelectionRequest(
+        XSelectionRequestEvent,
+        std::shared_ptr<X11Window>,
+        X11Atom const& target,
+        X11Atom const& property,
+        bool multiple
+    );
+
+public:
+    X11SelectionRequest(X11Connection&, XSelectionRequestEvent);
+
+    [[nodiscard]] inline XSelectionRequestEvent const& event() const { return m_event; }
+    [[nodiscard]] inline X11Connection& connection() const { return m_window->connection(); }
+    [[nodiscard]] inline X11Window& window() const { return *m_window; }
+    [[nodiscard]] inline std::shared_ptr<X11Window> windowPtr() const { return m_window; }
+    [[nodiscard]] inline X11Atom const& target() const { return m_target; }
+    [[nodiscard]] inline X11Atom const& property() const { return m_property; }
+    [[nodiscard]] inline bool isMultiple() const { return m_multiple; }
+
+    X11SelectionRequest forMultiple(X11Atom const& target, X11Atom const& property) const;
+};
+
+class X11SelectionTransfer {
+protected:
+    bool m_done = false;
+
+public:
+    [[nodiscard]] inline bool isDone() const { return m_done; }
+    virtual void handle(XEvent const&) = 0;
+};
+
+class X11IncrTransfer : public X11SelectionTransfer {
+private:
+    std::shared_ptr<X11Window> m_window;
+    X11Property m_property;
+    std::size_t m_offset;
+    bool m_sentTrailer = false;
+
+    [[nodiscard]] inline X11Connection& connection() const { return m_window->connection(); }
+    [[nodiscard]] inline std::size_t chunkSize() const { return connection().maxDataSizeForIncr() / m_property.format().size(); }
+public:
+    X11IncrTransfer(std::shared_ptr<X11Window>, X11Property&&);
+    void handle(XEvent const&) override;
+};
+
+class X11SelectionDaemon {
+private:
+    X11Connection& m_connection;
+    X11Atom const& m_selection;
+    ClipboardContent const& m_content;
+
+    X11Window m_window;
+    Time m_selectionAcquiredTime;
+    bool m_isSelectionOwner;
+
+    std::vector<std::unique_ptr<X11SelectionTransfer>> m_transfers;
+
+    XEvent nextEvent();
+    static XEvent makeSelectionNotify(XSelectionRequestEvent const&);
+    void refuseSelectionRequest(XSelectionRequestEvent const&) const;
+    bool refuseSelectionRequest(X11SelectionRequest const&) const;
+
+    template<ranges::contiguous_range range_t>
+    bool replySelectionRequest(X11SelectionRequest const&, X11Atom const& type, range_t);
+
+    void handle(XEvent const&);
+    void handleSelectionClear(XSelectionClearEvent const&);
+    void handleSelectionRequest(XSelectionRequestEvent const&);
+    bool handleSelectionRequest(X11SelectionRequest const&);
+
+    bool handleMultipleSelectionRequest(X11SelectionRequest const&);
+    bool handleTimestampSelectionRequest(X11SelectionRequest const&);
+    bool handleTargetsSelectionRequest(X11SelectionRequest const&);
+    bool handleRegularSelectionRequest(X11SelectionRequest const&);
+    bool handlePathsSelectionRequest(X11SelectionRequest const&, X11ClipboardType const&);
+    bool handleTextSelectionRequest(X11SelectionRequest const&, X11ClipboardType const&);
+
+public:
+    explicit X11SelectionDaemon(X11Connection&, X11Atom const& selection, ClipboardContent const&);
+
+    [[nodiscard]] inline X11Connection& connection() const { return m_connection; }
+    [[nodiscard]] inline X11Atom const& selection() const { return m_selection; }
+    [[nodiscard]] inline X11Window& window() { return m_window; }
+    [[nodiscard]] inline ClipboardContent const& content() const { return m_content; }
+    [[nodiscard]] inline bool isSelectionOwner() const { return m_isSelectionOwner; }
+
+    [[nodiscard]] inline X11Atom const& atom(char const* name) const { return m_connection.atom(name); }
+    [[nodiscard]] inline X11Atom const& atom(Atom value) const { return m_connection.atom(value); }
+
+    void run();
+};
+
+template<typename Return, typename Func>
+static Return poll(Func func) {
+    auto const startTime = chrono::steady_clock::now();
+    auto backoffTime = startEventPollBackoff;
+
+    std::optional<Return> result;
+    while (!(result = func()).has_value()) {
+        debugStream << "No poll data, sleeping" << std::endl;
+
+        auto const time = chrono::steady_clock::now() - startTime;
+        if (time >= maxEventPollTime) {
+            debugStream << "Timeout during poll" << std::endl;
+            throw X11Exception("Timeout during poll");
+        }
+
+        std::this_thread::sleep_for(backoffTime);
+        backoffTime = eventPollBackoffMultiplier * backoffTime;
+        if (backoffTime > maxEventPollBackoffTime) {
+            backoffTime = maxEventPollBackoffTime;
+        }
+    }
+
+    debugStream << "Poll finished successfully, got a result" << std::endl;
+    return result.value();
+}
+
+static std::string urlEncode(std::string const& value) {
+    static std::set<char> const allowedCharacters {
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+        'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+        'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+        '-', '_', '.', '~', '/'
+    };
+
+    std::stringstream result;
+    for (auto&& c : value) {
+        if (allowedCharacters.contains(c)) {
+            result << c;
+            continue;
+        }
+
+        result
+                << "%"
+                << std::hex
+                << std::uppercase
+                << std::setw(2)
+                << std::setfill('0')
+                << static_cast<std::uint64_t>(static_cast<std::uint8_t>(c));
+    }
+
+    return result.str();
+}
 
 void X11ClipboardType::tryPopulateTypesByName() {
     if (!s_typesByName.empty()) {
@@ -335,9 +553,20 @@ void X11ClipboardType::tryPopulateTypesByName() {
     }
 
     unsigned int priority = 0;
-    for (auto&& [ name, type ] : s_knownTypes) {
-        s_typesByName.insert({ name, { priority++, name, type } });
+    for (auto&& [ name, type, options ] : s_knownTypes) {
+        s_typesByName.insert({ name, { priority++, name, type, options } });
     }
+}
+
+std::optional<X11ClipboardType> X11ClipboardType::find(X11Atom const& atom) {
+    tryPopulateTypesByName();
+
+    auto&& it = s_typesByName.find(atom.name());
+    if (it == s_typesByName.end()) {
+        return {};
+    }
+
+    return it->second;
 }
 
 std::optional<X11ClipboardType> X11ClipboardType::findBest(std::vector<std::reference_wrapper<const X11Atom>> const& targets) {
@@ -347,20 +576,31 @@ std::optional<X11ClipboardType> X11ClipboardType::findBest(std::vector<std::refe
     for (auto&& target : targets) {
         debugStream << "Advertised target: " << target.get().name() << std::endl;
 
-        auto&& it = s_typesByName.find(target.get().name());
-        if (it == s_typesByName.end()) {
+        auto found = find(target.get());
+        if (!found.has_value()) {
             continue;
         }
 
-        X11ClipboardType found = it->second;
-        if (best.has_value() && best->priority() <= found.priority()) {
+        if (best.has_value() && best->priority() <= found->priority()) {
             continue;
         }
 
-        best.emplace(found);
+        best.emplace(*found);
     }
 
     return best;
+}
+
+bool X11ClipboardType::supports(ClipboardContent const& content) const {
+    if (type() == content.type()) {
+        return true;
+    }
+
+    if (type() == ClipboardContentType::Text && content.type() == ClipboardContentType::Paths) {
+        return true;
+    }
+
+    return false;
 }
 
 std::string_view X11Atom::name() const {
@@ -377,6 +617,15 @@ std::string_view X11Atom::name() const {
 bool X11Atom::operator==(const X11Atom &other) const {
     return m_value == other.m_value;
 }
+
+bool X11Atom::operator==(Atom const& other) const {
+    return m_value == other;
+}
+
+bool X11Atom::operator==(std::string_view const& other) const {
+    return name() == other;
+}
+
 
 int X11Connection::globalErrorHandler(Display* const display, XErrorEvent* const event) {
     if (instance != nullptr) {
@@ -528,14 +777,92 @@ void X11Connection::throwIfDestroyed() const {
     }
 }
 
+XEvent X11Connection::nextEvent() {
+    XEvent result;
+    X_CALL(XNextEvent, display(), &result);
+    return result;
+}
+
+std::optional<XEvent> X11Connection::checkMaskEvent(int eventMask) {
+    XEvent result;
+    if (X_CALL(XCheckMaskEvent, display(), eventMask, &result)) {
+        return result;
+    }
+
+    return {};
+}
+
 Window X11Connection::getSelectionOwner(const X11Atom& selection) {
     throwIfDestroyed();
     return X_CALL(XGetSelectionOwner, display(), selection.value());
 }
 
+void X11Connection::sendEvent(Window window, bool propagate, long eventMask, XEvent& event) {
+    auto status = X_CALL(XSendEvent,
+        display(),
+        window,
+        propagate,
+        eventMask,
+        &event
+    );
+    if (status == 0) {
+        throw X11Exception("XSendEvent failed");
+    }
+}
+
 bool X11Connection::isClipboardOwned() {
     throwIfDestroyed();
     return getSelectionOwner(atom(atomClipboard)) != None;
+}
+
+std::shared_ptr<X11Window> X11Connection::externalWindow(Window window) {
+    if (m_externalWindows.contains(window)) {
+        auto cached = m_externalWindows[window];
+        if (!cached.expired()) {
+            return cached.lock();
+        }
+
+        m_externalWindows.erase(window);
+    }
+
+    auto result = std::make_shared<X11Window>(*this, window, false);
+    m_externalWindows[window] = result;
+
+    return result;
+}
+
+template<ranges::contiguous_range range_t, typename char_t>
+X11Property::X11Property(
+    X11Atom const& name,
+    X11Atom const& type,
+    range_t data,
+    bool owned
+) : X11Property(
+    name,
+    type,
+    X11PropertyFormat::fromSize(sizeof(char_t)),
+    data,
+    owned
+) { }
+
+template<ranges::contiguous_range range_t, typename char_t>
+X11Property::X11Property(
+    X11Atom const& name,
+    X11Atom const& type,
+    X11PropertyFormat const& format,
+    range_t data,
+    bool owned
+) : m_name(name)
+  , m_type(type)
+  , m_format(format)
+  , m_size8(data.size() * sizeof(char_t)) {
+    if (owned) {
+        auto data8 = std::make_unique<std::uint8_t[]>(m_size8);
+        std::memcpy(data8.get(), &data[0], m_size8);
+        m_data8.emplace<std::unique_ptr<std::uint8_t[]>>(std::move(data8));
+    } else {
+        m_data8.emplace<std::uint8_t const*>(reinterpret_cast<std::uint8_t const*>(&data[0]));
+    }
 }
 
 X11PropertyIterator X11Property::begin() const {
@@ -544,6 +871,20 @@ X11PropertyIterator X11Property::begin() const {
 
 X11PropertyIterator X11Property::end() const {
     return { *this, size() };
+}
+
+X11Property X11Property::range(std::size_t start, std::size_t end) {
+    start = std::min(start, size());
+    end = std::clamp(end, start, size());
+
+    auto begin = data8() + (start * format().size());
+    auto count = (end - start) * format().size();
+    return {
+        name(),
+        type(),
+        views::counted(begin, count),
+        false
+    };
 }
 
 std::partial_ordering X11PropertyIterator::operator<=>(X11PropertyIterator const& other) const {
@@ -582,8 +923,12 @@ X11PropertyIterator::operator bool() const {
 }
 
 X11Window::X11Window(X11Connection& connection, Window window)
+    : X11Window(connection, window, true) { }
+
+X11Window::X11Window(X11Connection& connection, Window window, bool owned)
         : m_connection(connection)
-        , m_window(window) {
+        , m_window(window)
+        , m_owned(owned) {
 
     if (m_window == None) {
         throw X11Exception("Invalid Window");
@@ -591,8 +936,12 @@ X11Window::X11Window(X11Connection& connection, Window window)
 }
 
 X11Window::~X11Window() {
-    XDestroyWindow(display(), m_window);
-    m_window = None;
+    clearEventMask();
+
+    if (m_owned) {
+        X_CALL(XDestroyWindow, display(), m_window);
+        m_window = None;
+    }
 }
 
 void X11Window::throwIfDestroyed() const {
@@ -621,8 +970,9 @@ std::optional<XEvent> X11Window::checkMaskEvent(int eventMask) {
     return {};
 }
 
-void X11Window::changeProperty(X11PropertyMode mode, X11Property& value) {
+void X11Window::changeProperty(X11PropertyMode mode, X11Property const& value) {
     throwIfDestroyed();
+
     X_CALL(XChangeProperty,
         display(),
         window(),
@@ -640,53 +990,31 @@ void X11Window::deleteProperty(X11Atom const& property) {
     X_CALL(XDeleteProperty, display(), window(), property.value());
 }
 
-template<typename predicate_t>
+template<std::predicate<XEvent const&> predicate_t>
 XEvent X11Window::waitForEvent(int eventType, predicate_t predicate) {
     throwIfDestroyed();
 
     debugStream << "Waiting for event " << eventType << std::endl;
-
-    auto const startTime = chrono::steady_clock::now();
-    auto backoffTime = startEventPollBackoff;
-
-    std::optional<XEvent> event;
-    while (
-        !(event = checkTypedWindowEvent(eventType)).has_value()
-        || !predicate(event.value())
-    ) {
-        if (event.has_value()) {
-            debugStream << "Got an event but it didn't match the predicate, sleeping" << std::endl;
-        } else {
-            debugStream << "No events, sleeping" << std::endl;
+    return poll<XEvent>([this, eventType, &predicate]() -> std::optional<XEvent> {
+        auto event = checkTypedWindowEvent(eventType);
+        if (event.has_value() && !predicate(event.value())) {
+            return {};
         }
 
-        auto const time = chrono::steady_clock::now() - startTime;
-        if (time >= maxEventPollTime) {
-            debugStream << "Timeout waiting for event" << std::endl;
-            throw X11Exception("Timed-out waiting for an event");
-        }
-
-        std::this_thread::sleep_for(backoffTime);
-        backoffTime = eventPollBackoffMultiplier * backoffTime;
-        if (backoffTime > maxEventPollBackoffTime) {
-            backoffTime = maxEventPollBackoffTime;
-        }
-    }
-
-    debugStream << "Got the event we were waiting for" << std::endl;
-    return event.value();
+        return event;
+    });
 }
 
 Time X11Window::queryCurrentTime() {
     throwIfDestroyed();
 
     auto&& name = atom("GETCURRENTTIME");
-    X11Property value { name, atom("text/plain"), u8"getcurrenttime"sv };
+    X11Property value { name, atom("text/plain"), u8"getcurrenttime"sv, false };
 
     deleteProperty(name);
     changeProperty(X11PropertyMode::Replace, value);
 
-    auto const event = waitForEvent(PropertyNotify, [&name](XEvent& event) {
+    auto const event = waitForEvent(PropertyNotify, [&name](XEvent const& event) {
         return event.xproperty.atom == name.value() && event.xproperty.state == PropertyNewValue;
     });
 
@@ -710,7 +1038,7 @@ X11Property X11Window::convertSelection(X11Atom const& selection, X11Atom const&
         queryCurrentTime()
     );
 
-    auto const result = waitForEvent(SelectionNotify, [requestor, &selection, &target](XEvent& event) {
+    auto const result = waitForEvent(SelectionNotify, [requestor, &selection, &target](XEvent const& event) {
         auto& xselection = event.xselection;
         return xselection.requestor == requestor
                && xselection.selection == selection.value()
@@ -759,21 +1087,19 @@ X11Property X11Window::getProperty(X11Atom const& name, bool delet) {
 
     auto&& type = atom(actualTypeReturn);
     auto const format = X11PropertyFormat::fromValue(actualFormatReturn);
-
     auto const size = nitemsReturn * format.size();
-    auto data = std::make_unique<std::uint8_t[]>(size);
-    std::memcpy(data.get(), x11Data.get(), size);
 
     return X11Property {
         name,
         type,
         format,
-        std::move(data),
-        size
+        views::counted(x11Data.get(), size),
+        true
     };
 }
 
 X11Property X11Window::convertClipboard(const X11Atom &target) {
+    throwIfDestroyed();
     return convertSelection(atom(atomClipboard), target);
 }
 
@@ -832,6 +1158,487 @@ std::vector<char> X11Window::getClipboardData(X11Atom const& target) {
     return result;
 }
 
+void X11Window::setSelectionOwner(const X11Atom &selection, Time time) {
+    throwIfDestroyed();
+
+    X_CALL(XSetSelectionOwner, display(), selection.value(), window(), time);
+
+    if (connection().getSelectionOwner(selection) != window()) {
+        throw X11Exception("XSetSelectionOwner merely appeared to succeed, probably timing issues");
+    }
+}
+
+void X11Window::changeWindowAttributes(unsigned long valuemask, XSetWindowAttributes* attributes) {
+    throwIfDestroyed();
+
+    X_CALL(XChangeWindowAttributes,
+       display(),
+       window(),
+       valuemask,
+       attributes
+   );
+}
+
+void X11Window::setEventMask(long eventMask) {
+    throwIfDestroyed();
+
+    XSetWindowAttributes attributes = {
+            .event_mask = eventMask
+    };
+
+    changeWindowAttributes(CWEventMask, &attributes);
+}
+
+XWindowAttributes X11Window::getWindowAttributes() {
+    throwIfDestroyed();
+
+    XWindowAttributes attributes;
+    auto status = X_CALL(XGetWindowAttributes, display(), window(), &attributes);
+    if (status == 0) {
+        throw X11Exception("XGetWindowAttributes: failed to get window attributes");
+    }
+
+    return attributes;
+}
+
+void X11Window::addToEventMask(long eventMask) {
+    throwIfDestroyed();
+
+    auto attributes = getWindowAttributes();
+    auto newMask = attributes.your_event_mask | eventMask;
+    setEventMask(newMask);
+}
+
+void X11Window::clearEventMask() {
+    throwIfDestroyed();
+    setEventMask(NoEventMask);
+}
+
+void X11Window::addPropertyChangeToEventMask() {
+    throwIfDestroyed();
+    addToEventMask(PropertyChangeMask);
+}
+
+void X11Window::sendEvent(bool propagate, long eventMask, XEvent& event) {
+    throwIfDestroyed();
+    connection().sendEvent(window(), propagate, eventMask, event);
+}
+
+bool X11Window::operator==(X11Window const& other) const {
+    return m_window == other.m_window;
+}
+
+bool X11Window::operator==(Window const& other) const {
+    return m_window == other;
+}
+
+X11SelectionRequest::X11SelectionRequest(
+    XSelectionRequestEvent event,
+    std::shared_ptr<X11Window> window,
+    X11Atom const& target,
+    X11Atom const& property,
+    bool multiple)
+    : m_event(event)
+    , m_window(std::move(window))
+    , m_target(target)
+    , m_property(property)
+    , m_multiple(multiple) { }
+
+X11SelectionRequest::X11SelectionRequest(
+    X11Connection& connection,
+    XSelectionRequestEvent event)
+    : m_window(connection.externalWindow(event.requestor))
+    , m_property(connection.atom(event.property == None ? event.target : event.property))
+    , m_target(connection.atom(event.target))
+    , m_event(event)
+    , m_multiple(false) {
+
+}
+
+X11SelectionRequest X11SelectionRequest::forMultiple(X11Atom const& target, X11Atom const& property) const {
+    return {
+        event(),
+        windowPtr(),
+        target,
+        property,
+        true
+    };
+}
+
+X11IncrTransfer::X11IncrTransfer(
+    std::shared_ptr<X11Window> window,
+    X11Property&& property
+) : m_window(std::move(window))
+  , m_property(std::move(property))
+  , m_offset(0) {
+
+}
+
+void X11IncrTransfer::handle(XEvent const& event) {
+    if (m_done) {
+        return;
+    }
+
+    auto isIncr =
+            event.type == PropertyNotify
+            && event.xproperty.window == *m_window
+            && event.xproperty.atom == m_property.name()
+            && event.xproperty.state == PropertyDelete;
+
+    if (!isIncr) {
+        return;
+    }
+
+    if (m_sentTrailer) {
+        debugStream << "INCR:  Final zero-byte property deleted, transfer is over" << std::endl;
+        m_done = true;
+        return;
+    }
+
+   auto partialProp = m_property.range(m_offset, m_offset + chunkSize());
+    m_offset += partialProp.size();
+
+    debugStream << "INCR: Sending " << partialProp.size8() << " bytes" << std::endl;
+    m_window->changeProperty(X11PropertyMode::Replace, partialProp);
+
+    if (partialProp.size8() == 0) {
+        m_sentTrailer = true;
+    }
+}
+
+X11SelectionDaemon::X11SelectionDaemon(
+        X11Connection& connection,
+        X11Atom const& selection,
+        ClipboardContent const& content)
+    : m_connection(connection)
+    , m_selection(selection)
+    , m_window(connection.createWindow())
+    , m_content(content)
+    , m_isSelectionOwner(true) {
+
+    debugStream << "Setting the selection owner to ourselves" << std::endl;
+    m_selectionAcquiredTime = window().queryCurrentTime();
+    window().setSelectionOwner(selection, m_selectionAcquiredTime);
+}
+
+XEvent X11SelectionDaemon::nextEvent() {
+    if (isSelectionOwner()) {
+        return connection().nextEvent();
+    }
+
+    // If we don't own the selection anymore, we're only alive to finish serving requests made before
+    // we lost the selection ownership. To prevent the daemon from staying up forever, we switch to
+    // polling to ensure we'll fail if all ongoing requests are stalled.
+
+    return poll<XEvent>([this]() {
+        return connection().checkMaskEvent(std::numeric_limits<int>::max());
+    });
+}
+
+XEvent X11SelectionDaemon::makeSelectionNotify(XSelectionRequestEvent const& event) {
+    return XEvent {
+        .xselection = {
+            .type = SelectionNotify,
+            .display = event.display,
+            .requestor = event.requestor,
+            .selection = event.selection,
+            .target = event.target,
+            .property = event.property,
+            .time = event.time,
+        }
+    };
+}
+
+void X11SelectionDaemon::refuseSelectionRequest(XSelectionRequestEvent const& event) const {
+    auto refusal = makeSelectionNotify(event);
+    refusal.xselection.property = None;
+
+    connection().sendEvent(
+        event.requestor,
+        false,
+        NoEventMask,
+        refusal
+    );
+}
+
+bool X11SelectionDaemon::refuseSelectionRequest(X11SelectionRequest const& request) const {
+    auto refusal = makeSelectionNotify(request.event());
+    refusal.xselection.property = None;
+    request.window().sendEvent(false, NoEventMask, refusal);
+    return false;
+}
+
+template<ranges::contiguous_range range_t>
+bool X11SelectionDaemon::replySelectionRequest(X11SelectionRequest const& request, X11Atom const& type, range_t data) {
+    X11Property property {
+        request.property(),
+        type,
+        data,
+        true
+    };
+    debugStream
+        << "Replying with " << property.size8() << " bytes of data"
+        << " at format " << property.format().value()
+        << " and type " << property.type().name()
+        << std::endl;
+
+    if (data.size() > connection().maxDataSizeForIncr()) {
+        debugStream << "Data too big, using INCR mechanism" << std::endl;
+        X11Property incrProperty {
+            property.name(),
+            atom(atomIncr),
+            views::single(property.size8()),
+            true
+        };
+        request.window().addPropertyChangeToEventMask();
+        request.window().changeProperty(X11PropertyMode::Replace, incrProperty);
+        m_transfers.emplace_back(std::make_unique<X11IncrTransfer>(request.windowPtr(), std::move(property)));
+
+    } else {
+        request.window().changeProperty(X11PropertyMode::Replace, property);
+    }
+
+    if (!request.isMultiple()) {
+        auto selectionNotify = makeSelectionNotify(request.event());
+        request.window().sendEvent(false, NoEventMask, selectionNotify);
+    }
+
+    return true;
+}
+
+void X11SelectionDaemon::handle(XEvent const& event) {
+    if (event.type == SelectionClear) {
+        handleSelectionClear(event.xselectionclear);
+
+    } else if (event.type == SelectionRequest) {
+        handleSelectionRequest(event.xselectionrequest);
+
+    }
+}
+
+void X11SelectionDaemon::handleSelectionClear(XSelectionClearEvent const& event) {
+    if (event.selection == selection()) {
+        debugStream << "Selection cleared, we are no longer the owners of the selection" << std::endl;
+        m_isSelectionOwner = false;
+    }
+}
+
+void X11SelectionDaemon::handleSelectionRequest(XSelectionRequestEvent const& event) {
+    if (!isSelectionOwner()) {
+        debugStream << "Selection request received after we lost selection ownership, refusing" << std::endl;
+        return refuseSelectionRequest(event);
+    }
+
+    if (event.owner != window()) {
+        debugStream << "Selection request has incorrect owner window, refusing" << std::endl;
+        return refuseSelectionRequest(event);
+    }
+
+    if (event.selection != selection()) {
+        debugStream << "Selection request has incorrect selection " << atom(event.selection).name() << ", refusing" << std::endl;
+        return refuseSelectionRequest(event);
+    }
+
+    if (event.time != CurrentTime && event.time < m_selectionAcquiredTime) {
+        debugStream << "Selection request time " << event.time << " is from before we acquired selection ownership at " << m_selectionAcquiredTime <<", refusing" << std::endl;
+        return refuseSelectionRequest(event);
+    }
+
+    if (event.requestor == None) {
+        debugStream << "Selection request has no requestor, refusing" << std::endl;
+        return refuseSelectionRequest(event);
+    }
+
+    handleSelectionRequest({ connection(), event });
+}
+
+bool X11SelectionDaemon::handleSelectionRequest(X11SelectionRequest const& request) {
+    debugStream
+        << "Got a selection request from " << request.window().window()
+        << " for target " << request.target().name()
+        << " on property " << request.property().name()
+        << std::endl;
+
+    if (request.target() == atomMultiple) {
+        return handleMultipleSelectionRequest(request);
+    }
+
+    if (request.target() == atomTargets) {
+        return handleTargetsSelectionRequest(request);
+    }
+
+    if (request.target() == atomTimestamp) {
+        return handleTimestampSelectionRequest(request);
+    }
+
+    return handleRegularSelectionRequest(request);
+}
+
+bool X11SelectionDaemon::handleMultipleSelectionRequest(X11SelectionRequest const& request) {
+    std::optional<X11Property> pairs;
+    try {
+        pairs.emplace(request.window().getProperty(request.property()));
+    } catch (X11Exception const& e) {
+        debugStream << "Error trying to get MULTIPLE atom pair: " << e.what() << ", refusing" << std::endl;
+        return refuseSelectionRequest(request);
+    }
+
+    if (pairs->type() != atomAtomPair) {
+        debugStream << "MULTIPLE property parameter isn't an atom pair, refusing" << std::endl;
+        return refuseSelectionRequest(request);
+    }
+
+    std::vector<std::uint64_t> result;
+    std::optional<std::uint64_t> target;
+    for (auto&& value : *pairs) {
+        if (!target) {
+            target = value;
+            result.push_back(value);
+            continue;
+        }
+
+        auto newRequest = request.forMultiple(atom(*target), atom(value));
+        if (handleSelectionRequest(newRequest)) {
+            result.push_back(value);
+        } else {
+            result.push_back(None);
+        }
+    }
+
+    return replySelectionRequest(request, atom(atomAtomPair), result);
+}
+
+bool X11SelectionDaemon::handleTargetsSelectionRequest(X11SelectionRequest const& request) {
+    std::vector<std::uint64_t> data {
+        atom(atomTargets).value(),
+        atom(atomMultiple).value(),
+        atom(atomTimestamp).value(),
+    };
+    for (auto&& type : X11ClipboardType::all()) {
+        if (type.supports(content())) {
+            data.push_back(atom(type.name()).value());
+        }
+    }
+
+    for (auto&& value : data) {
+        debugStream << "Advertising target: " << atom(value).name() << std::endl;
+    }
+
+    return replySelectionRequest(request, atom(atomAtom), data);
+}
+
+bool X11SelectionDaemon::handleTimestampSelectionRequest(X11SelectionRequest const& event) {
+    debugStream << "Got a TIMESTAMP request" << std::endl;
+    debugStream << "Replying with: " << m_selectionAcquiredTime << std::endl;
+
+    std::vector<std::uint64_t> data { m_selectionAcquiredTime };
+    return replySelectionRequest(event, atom(atomInteger), data);
+}
+
+bool X11SelectionDaemon::handleRegularSelectionRequest(X11SelectionRequest const& request) {
+    auto type = X11ClipboardType::find(request.target());
+    if (!type.has_value()) {
+        debugStream << "Target not recognized, refusing" << std::endl;
+        return refuseSelectionRequest(request);
+    }
+
+    if (type->isChooseBestType()) {
+        auto all = X11ClipboardType::all();
+        auto bestType = std::find_if(all.begin(), all.end(), [&](X11ClipboardType const& value) -> bool {
+            return value.supports(content()) && !value.isChooseBestType();
+        });
+
+        if (bestType == all.end()) {
+            throw X11Exception("Unable to find proper target");
+        }
+
+        type.emplace(*bestType);
+    }
+
+    if (!type->supports(content())) {
+        debugStream << "Target is incompatible with the clipboard content, refusing" << std::endl;
+        return refuseSelectionRequest(request);
+    }
+
+    if (content().type() == ClipboardContentType::Paths) {
+        return handlePathsSelectionRequest(request, *type);
+    } else if (content().type() == ClipboardContentType::Text) {
+        return handleTextSelectionRequest(request, *type);
+    } else {
+        debugStream << "Unknown clipboard content, refusing" << std::endl;
+        return refuseSelectionRequest(request);
+    }
+}
+
+bool X11SelectionDaemon::handlePathsSelectionRequest(X11SelectionRequest const& request, X11ClipboardType const& type) {
+    auto&& paths = content().paths();
+
+    std::stringstream data;
+    if (type.isIncludeAction()) {
+        if (paths.action() == ClipboardPathsAction::Cut) {
+            data << "cut" << std::endl;
+        } else {
+            data << "copy" << std::endl;
+        }
+    }
+
+    bool first = true;
+    for (auto&& path : paths.paths()) {
+        if (!first) {
+            data << std::endl;
+        }
+
+        if (type.isEncodePaths()) {
+            data << "file://" << urlEncode(path.string());
+        } else {
+            data << path.string();
+        }
+
+        first = false;
+    }
+
+    debugStream << "Replying with: " << std::endl << data.str() << std::endl;
+    return replySelectionRequest(
+            request,
+            atom(type.name()),
+            data.str()
+    );
+}
+
+bool X11SelectionDaemon::handleTextSelectionRequest(X11SelectionRequest const& request, X11ClipboardType const& type) {
+    return replySelectionRequest(
+        request,
+        atom(type.name()),
+        content().text()
+    );
+}
+
+void X11SelectionDaemon::run() {
+    debugStream << "Starting persistent paste daemon" << std::endl;
+
+    while (true) {
+        auto event = nextEvent();
+        handle(event);
+
+        for (auto&& transfer : m_transfers) {
+            transfer->handle(event);
+        }
+
+        std::erase_if(m_transfers, [](auto&& transfer) {
+            return transfer->isDone();
+        });
+
+        if (!m_transfers.empty()) {
+            debugStream << m_transfers.size() << " transfers are in progress" << std::endl;
+        }
+
+        if (!isSelectionOwner() && m_transfers.empty()) {
+            debugStream << "Ownership lost and transfers are done, exiting" << std::endl;
+            break;
+        }
+    }
+}
+
 static std::string urlDecode(std::string const& value) {
     auto tryConvertByte = [](std::string const& str) -> std::optional<char> {
         std::size_t pos = 0;
@@ -875,6 +1682,8 @@ static std::string parseText(std::vector<char> const& data) {
 
 static ClipboardPaths parseFiles(std::vector<char> const& data) {
     std::string dataStr { data.begin(), data.end() };
+    debugStream << "Parsing buffer as files, raw data:" << std::endl << dataStr << std::endl;
+
     std::istringstream stream { dataStr };
 
     ClipboardPathsAction action = ClipboardPathsAction::Copy;
@@ -934,4 +1743,30 @@ ClipboardContent getX11ClipboardInternal() {
     }
 
     return { parseFiles(data) };
+}
+
+static void startPasteDaemon(ClipboardContent const& clipboard) {
+    X11Connection conn;
+    X11SelectionDaemon daemon { conn, conn.atom(atomClipboard), clipboard };
+    daemon.run();
+}
+
+void setX11ClipboardInternal(ClipboardContent const& clipboard) {
+    bool noFork = std::getenv("CLIPBOARD_X11_NO_FORK") != nullptr;
+    if (!noFork && fork() != 0) {
+        debugStream << "Successfully spawned X11 paste daemon" << std::endl;
+        return;
+    }
+
+    debugStream << "We are the X11 paste daemon, hijacking operation" << std::endl;
+    try {
+        startPasteDaemon(clipboard);
+    } catch (std::exception const& e) {
+        debugStream << "Error during X11 daemon operation: " << e.what() << std::endl;
+    }
+
+    // Always exit no matter what happens, to prevent the forked daemon
+    // from returning control to the stack frames above and overwriting the
+    // non-forked original process' work
+    std::exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
This PR implements pasting for X11, meaning that it'll be possible to paste text or files copied from `clipboard` into other applications.

This is done by forking `clipboard` and using the fork as a paste daemon that replies to X11 selection requests until another application steals the clipboard. The daemon exits automatically when it has no more work to do.