### PR TITLE
Add CI jobs for GCC 10, 11, and 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,19 +5,24 @@ jobs:
   build-linux_x11_wayland-amd64:
     runs-on: ubuntu-22.04
 
+    strategy:
+      fail-fast: false
+      matrix:
+        gcc: [ 10, 11, 12 ]
+
     steps:
       - uses: actions/checkout@v3
 
       - name: Run a multi-line script
         run: |
           sudo apt update
-          sudo apt install -y g++-12 libx11-dev libwayland-dev
+          sudo apt install -y g++-${{ matrix.gcc }} libx11-dev libwayland-dev
           cd build
-          cmake .. -D CMAKE_CXX_COMPILER=g++-12
+          cmake .. "-DCMAKE_CXX_COMPILER=g++-${{ matrix.gcc }}"
           cmake --build .
       - uses: actions/upload-artifact@v3
         with:
-          name: clipboard-linux-amd64
+          name: clipboard-linux-gcc${{ matrix.gcc }}-amd64
           path: build/output
   build-macos-amd64:
     runs-on: macos-11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,20 +5,12 @@ jobs:
   test-linux-amd64:
     runs-on: ubuntu-22.04
 
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Run a multi-line script
-        shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
-        run: |
-          cd build
-          cmake .. -D TEST=1 -D NO_X11=1 -D NO_WAYLAND=1
-          cmake --build .
-          sudo cmake --install .
-          export TMPDIR=/tmp
-          bash ../tests/suite.sh
-  test-linux_x11-amd64:
-    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        gcc: [ 10, 11, 12 ]
+        x11: [ "1", "0" ]
+        wayland: [ "1", "0" ]
 
     steps:
       - uses: actions/checkout@v3
@@ -26,48 +18,32 @@ jobs:
       - name: Run a multi-line script
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
         run: |
+          NO_X11=1
+          NO_WAYLAND=1
+          PACKAGES="g++-${{ matrix.gcc }}"
+
+          if [[ "${{ matrix.x11 }}" == "1" ]]
+          then
+            NO_X11=0
+            PACKAGES="${PACKAGES} libx11-dev"
+          fi
+          
+          if [[ "${{ matrix.wayland }}" == "1" ]]
+          then
+            NO_WAYLAND=0
+            PACKAGES="${PACKAGES} libwayland-dev"
+          fi
+          
           sudo apt update
-          sudo apt install -y libx11-dev
+          sudo apt install -y $PACKAGES
+
           cd build
-          cmake .. -D TEST=1 -D NO_WAYLAND=1
+          cmake .. "-DTEST=1" "-DCMAKE_CXX_COMPILER=g++-${{ matrix.gcc }}" "-DNO_X11=${NO_X11}" "-DNO_WAYLAND=${NO_WAYLAND}"
           cmake --build .
           sudo cmake --install .
           export TMPDIR=/tmp
           bash ../tests/suite.sh
-  test-linux_wayland-amd64:
-    runs-on: ubuntu-22.04
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Run a multi-line script
-        shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
-        run: |
-          sudo apt update
-          sudo apt install -y libwayland-dev
-          cd build
-          cmake .. -D TEST=1 -D NO_X11=1
-          cmake --build .
-          sudo cmake --install .
-          export TMPDIR=/tmp
-          bash ../tests/suite.sh
-  test-linux_x11_wayland-amd64:
-    runs-on: ubuntu-22.04
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Run a multi-line script
-        shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
-        run: |
-          sudo apt update
-          sudo apt install -y libx11-dev libwayland-dev
-          cd build
-          cmake .. -D TEST=1
-          cmake --build .
-          sudo cmake --install .
-          export TMPDIR=/tmp
-          bash ../tests/suite.sh
+  
   test-macos-amd64:
     runs-on: macos-11
 

--- a/src/clipboard/CMakeLists.txt
+++ b/src/clipboard/CMakeLists.txt
@@ -37,6 +37,10 @@ set(THREADS_PREFER_PTHREAD_FLAG True)
 find_package(Threads REQUIRED)
 target_link_libraries(clipboard Threads::Threads)
 
+if(CMAKE_DL_LIBS)
+  target_link_libraries(clipboard ${CMAKE_DL_LIBS})
+endif()
+
 if(WIN32)
   install(TARGETS clipboard DESTINATION bin)
 else()

--- a/src/clipboardx11/src/x11.cpp
+++ b/src/clipboardx11/src/x11.cpp
@@ -29,6 +29,7 @@
 #include <limits>
 #include <set>
 
+#include <unistd.h>
 #include <X11/Xlib.h>
 #include <clipboard/gui.hpp>
 #include <clipboard/logging.hpp>


### PR DESCRIPTION
This PR uses [Github Actions Matrices](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) to add CI jobs for GCC 10, 11, and 12, ensuring that we track compatibility with those compilers. It also fixes compatibility with GCC 10 by adding `-ldl` and `<unistd.h>` wherever necessary.