### PR TITLE
Add windows matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
         x11: [ "1", "0" ]
         wayland: [ "1", "0" ]
         arch: [ i386, amd64 ]
+        windows: [2022, 2019]
         exclude:
           - os: 20.04
             gcc: 12
@@ -86,7 +87,7 @@ jobs:
           cmake --install .
           bash ../tests/suite.sh
   test-windows-amd64:
-    runs-on: windows-latest
+    runs-on: windows-${{ matrix.windows }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
         x11: [ "1", "0" ]
         wayland: [ "1", "0" ]
         arch: [ i386, amd64 ]
-        windows: [2022, 2019]
         exclude:
           - os: 20.04
             gcc: 12
@@ -87,6 +86,10 @@ jobs:
           cmake --install .
           bash ../tests/suite.sh
   test-windows-amd64:
+    strategy:
+     matrix:
+       windows: [2022, 2019]
+     
     runs-on: windows-${{ matrix.windows }}
 
     steps:


### PR DESCRIPTION
This pr adds a matrix for windows. This is useful, because windows server 2019 is near to Windows 10 and server 2022 near to Windows 11, so Clipboard gets tested for both main windows version.