### PR TITLE
Add a redirection to the clipboard's repology webpage in the README when clicking the repology packaging status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,7 @@ Remove all the files in `install_manifest.txt`. If you're not using Windows, you
 
 ### **Premade Builds**
 
-<a>
-    <img src="https://repology.org/badge/vertical-allrepos/clipboard.svg" alt="Packaging status">
-</a>
+<a href="https://repology.org/project/clipboard/versions"><img src="https://repology.org/badge/vertical-allrepos/clipboard.svg" alt="Packaging status"></a>
 
 You can also download Clipboard [directly from GitHub Actions.](https://nightly.link/Slackadays/Clipboard/workflows/main/main)
 


### PR DESCRIPTION
Hi,

This PR adds a redirection to the [clipboard's repology webpage](https://repology.org/project/clipboard/versions) when clicking on the repology packaging status image in the README.
This link provides more details about the different `clipboard` packages, it allows people to easily be redirected to said packages' page by simply clicking on the desired one and it also provides useful information about their current maintainers.

*By the way, this is completely unrelated to this PR but I actually updated the 3 `clipboard*` AUR packages to v0.3.0 earlier today. The repology link just need a bit of time to update itself :smile:*