### PR TITLE
fix typo and add note that states that quick install doesn't work on nixos

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Now, have a _powerful_ clipboard to use **anywhere in the terminal**, just like 
 
 ![Clipboard Demo](documentation/readme-assets/ClipboardDemo.gif)
 ![Quick Installation](documentation/readme-assets/CBQuickInstallation.png)
+
+**NOTE:** This method **does not** work on NixOS.
+
 ### **All Except Windows** 
 ```bash
 curl -sSL https://github.com/Slackadays/Clipboard/raw/main/src/install.sh | sh
@@ -43,7 +46,7 @@ curl -sSL https://github.com/Slackadays/Clipboard/raw/main/src/install.sh | sh
 ### **Install Manually**
 Get the latest release instead by adding `--branch 0.3.1` right after `git clone...`. Change the installation prefix by adding `-DINSTALL_PREFIX=/CUSTOM/PREFIX` to `cmake ..`.
 ```bash
-git clone https://github.com/slackadays/Clipboard 
+git clone https://github.com/Slackadays/Clipboard 
 cd Clipboard/build
 cmake -DCMAKE_BUILD_TYPE=MinSizeRel ..
 cmake --build .


### PR DESCRIPTION
and it also can't find x11

![image](https://user-images.githubusercontent.com/119129086/217545442-5206769c-0016-4783-94f4-89fab2690716.png)

is nixos not compatible with clipboard? just because nixos doesn't have `/usr`?
