### PR TITLE
Use ARC with Objective-C code

### DIFF
--- a/src/clipboard/CMakeLists.txt
+++ b/src/clipboard/CMakeLists.txt
@@ -27,6 +27,7 @@ elseif(APPLE)
     src/macos.cpp
   )
   target_link_libraries(clipboard "-framework AppKit")
+  target_compile_options(clipboard PRIVATE -fobjc-arc)
 elseif(HAIKU)
   target_sources(clipboard PRIVATE
     src/haiku.cpp

--- a/src/clipboard/src/macos.m
+++ b/src/clipboard/src/macos.m
@@ -18,7 +18,8 @@ const char* textContent() {
     NSArray *classes = [[NSArray alloc] initWithObjects:[NSString class], [NSAttributedString class], nil];
     if ([[NSPasteboard generalPasteboard] canReadObjectForClasses:classes options:[NSDictionary dictionary]]) {
         NSString *text = [[NSPasteboard generalPasteboard] stringForType:NSPasteboardTypeString];
-        return [text UTF8String];
+        char* textContent = strdup([text UTF8String]);
+        return textContent;
     }
     return NULL;
 }


### PR DESCRIPTION
This pull request enables ARC (automatic reference counting) to make sure no objects are leaked in Objective-C code.