### PR TITLE
Correction of the install command for the AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ curl -sSL https://github.com/Slackadays/Clipboard/raw/main/src/install.sh | sh
 pkg add clipboard
 ```
 
-**AUR** (you can also get `clipboard-bin` and `clipboard-git`)
+**AUR** (Use your favorite AUR helper, example below with `yay`. You can also get `clipboard-bin` and `clipboard-git`)
 ```sh
-sudo pacman -S clipboard
+yay -S clipboard
 ```
 
 **Homebrew**


### PR DESCRIPTION
Hi,

This PR corrects the install command for the AUR. 
Indeed, `pacman` is not able to install AUR packages. You either have to install them manually by cloning the AUR git repo locally or by using an AUR helper (such as `yay` which *one of* the most popular one).

Clipboard does not meet the requirement in terms of popularity to be moved to Arch official repository yet but when it does, I'll consider moving it out the AUR so people will be able to simply use `pacman`  to install it. :)
