### PR TITLE
make use of CMAKE_INSTALL_LIBDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ if (MSVC)
   add_compile_definitions(NOMINMAX) # Prevent min() or max() from being made into macros by windows.h
 endif()
 
+if (NOT CMAKE_INSTALL_LIBDIR)
+  set(CMAKE_INSTALL_LIBDIR "lib")
+endif()
+
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Debug")
 endif()

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You'll need CMake and C++20 support, and if you want X11 and/or Wayland compatib
 
 Get the latest release instead of the latest commit by adding `--branch 0.6.0` right after `git clone...`.
 
-Change the system installation prefix by adding `-DCMAKE_INSTALL_PREFIX=/custom/prefix` to `cmake ..`.
+Change the system installation prefix by adding `-DCMAKE_INSTALL_PREFIX=/custom/prefix` to `cmake ..`, or the library install location by adding `-DCMAKE_INSTALL_LIBDIR=/custom/dir`.
 ```bash
 $ git clone https://github.com/Slackadays/Clipboard 
 $ cd Clipboard/build

--- a/src/clipboard/CMakeLists.txt
+++ b/src/clipboard/CMakeLists.txt
@@ -45,13 +45,13 @@ elseif(X11WL)
     TARGET clipboard
     APPEND
     PROPERTY BUILD_RPATH
-    "${CMAKE_INSTALL_PREFIX}/lib"
+    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
   )
   set_property(
     TARGET clipboard
     APPEND
     PROPERTY INSTALL_RPATH
-    "${CMAKE_INSTALL_PREFIX}/lib"
+    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
   )
   target_link_options(clipboard PRIVATE -z origin) # set the rpath to $ORIGIN
   target_link_libraries(clipboard ${CMAKE_DL_LIBS})

--- a/src/clipboardwayland/CMakeLists.txt
+++ b/src/clipboardwayland/CMakeLists.txt
@@ -71,4 +71,4 @@ target_include_directories(clipboardwayland PRIVATE
   ${GENERATED_INCLUDE_DIR}
 )
 
-install(TARGETS clipboardwayland LIBRARY DESTINATION lib)
+install(TARGETS clipboardwayland LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/clipboardx11/CMakeLists.txt
+++ b/src/clipboardx11/CMakeLists.txt
@@ -11,4 +11,4 @@ enable_lto(clipboardx11)
 
 target_include_directories(clipboardx11 PRIVATE ${X11_INCLUDE_DIR})
 
-install(TARGETS clipboardx11 LIBRARY DESTINATION lib)
+install(TARGETS clipboardx11 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Nice work.  I would like to include CMAKE_INSTALL_LIBDIR so the user can change the installation library directory if needed/wanted to -DCMAKE_INSTALL_LIBDIR=lib64 or lib32 for example.  I make use of lib64 on Gentoo myself.  If the user doesn't wish to change it then default to "lib".