### PR TITLE
Install script: only sudo mv if sudo is required

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -139,7 +139,6 @@ then
         curl -SL $download_link -o clipboard-linux.zip
         unzip clipboard-linux.zip
         rm clipboard-linux.zip
-        echo "Need sudo:" $requires_sudo
         if [ "$requires_sudo" = true ]
         then
             sudo mv bin/cb "$install_path/bin/cb"
@@ -147,7 +146,6 @@ then
             mv bin/cb "$install_path/bin/cb"
         fi
         chmod +x "$install_path/bin/cb"
-        echo "Need sudo:" $requires_sudo
         if [ -f "lib/libcbx11.so" ]
         then
             if [ "$requires_sudo" = true ]
@@ -157,7 +155,6 @@ then
                 mv lib/libcbx11.so "$install_path/lib/libcbx11.so"
             fi
         fi
-        echo "Need sudo:" $requires_sudo
         if [ -f "lib/libcbwayland.so" ]
         then
             if [ "$requires_sudo" = true ]
@@ -167,7 +164,6 @@ then
                 mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
             fi
         fi
-        echo "Need sudo:" $requires_sudo
     fi
 elif [ "$(uname)" = "Darwin" ]
 then

--- a/install.sh
+++ b/install.sh
@@ -161,7 +161,7 @@ then
             then
                 sudo mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
             else
-                sudo mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
+                mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
             fi
         fi
     fi

--- a/install.sh
+++ b/install.sh
@@ -139,6 +139,7 @@ then
         curl -SL $download_link -o clipboard-linux.zip
         unzip clipboard-linux.zip
         rm clipboard-linux.zip
+        echo "Need sudo:" $requires_sudo
         if [ "$requires_sudo" = true ]
         then
             sudo mv bin/cb "$install_path/bin/cb"
@@ -146,6 +147,7 @@ then
             mv bin/cb "$install_path/bin/cb"
         fi
         chmod +x "$install_path/bin/cb"
+        echo "Need sudo:" $requires_sudo
         if [ -f "lib/libcbx11.so" ]
         then
             if [ "$requires_sudo" = true ]
@@ -155,6 +157,7 @@ then
                 mv lib/libcbx11.so "$install_path/lib/libcbx11.so"
             fi
         fi
+        echo "Need sudo:" $requires_sudo
         if [ -f "lib/libcbwayland.so" ]
         then
             if [ "$requires_sudo" = true ]
@@ -164,6 +167,7 @@ then
                 mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
             fi
         fi
+        echo "Need sudo:" $requires_sudo
     fi
 elif [ "$(uname)" = "Darwin" ]
 then

--- a/install.sh
+++ b/install.sh
@@ -100,10 +100,12 @@ cd "$tmp_dir"
 
 if can_use_sudo
 then
+    requires_sudo=true
     install_path="/usr/local"
     sudo mkdir -p "$install_path/bin"
     sudo mkdir -p "$install_path/lib"
 else
+    requires_sudo=false
     install_path="$HOME/.local"
     mkdir -p "$install_path/bin"
     mkdir -p "$install_path/lib"
@@ -137,15 +139,30 @@ then
         curl -SL $download_link -o clipboard-linux.zip
         unzip clipboard-linux.zip
         rm clipboard-linux.zip
-        sudo mv bin/cb "$install_path/bin/cb"
+        if [ "$requires_sudo" = true ]
+        then
+            sudo mv bin/cb "$install_path/bin/cb"
+        else
+            mv bin/cb "$install_path/bin/cb"
+        fi
         chmod +x "$install_path/bin/cb"
         if [ -f "lib/libcbx11.so" ]
         then
-            sudo mv lib/libcbx11.so "$install_path/lib/libcbx11.so"
+            if [ "$requires_sudo" = true ]
+            then
+                sudo mv lib/libcbx11.so "$install_path/lib/libcbx11.so"
+            else
+                mv lib/libcbx11.so "$install_path/lib/libcbx11.so"
+            fi
         fi
         if [ -f "lib/libcbwayland.so" ]
         then
-            sudo mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
+            if [ "$requires_sudo" = true ]
+            then
+                sudo mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
+            else
+                sudo mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
+            fi
         fi
     fi
 elif [ "$(uname)" = "Darwin" ]


### PR DESCRIPTION
Currently, the install script attempts to detect when sudo is available and install to the `$HOME/.local` directory if it isn't, but when it moves the install files, it still does so using `sudo`, leading to installation failures.

This PR adds checks for whether sudo is required to perform the move operation - if the `requires_sudo` variable is `false`, the `mv` operations are performed without sudo.

Resolves #123