### PR TITLE
Add a theme based on the 3-bit ANSI colors

### DIFF
--- a/src/cb/src/themes.cpp
+++ b/src/cb/src/themes.cpp
@@ -75,5 +75,17 @@ void setTheme(const std::string_view& theme) {
                  {"[inverse]", "\033[7m"},
                  {"[noinverse]", "\033[27m"},
                  {"[blank]", "\033[0m"}}};
+    } else if (theme == "ansi") {
+        colors = {
+                {{"[error]", "\033[38;5;1m"},
+                 {"[success]", "\033[38;5;2m"},
+                 {"[progress]", "\033[38;5;3m"},
+                 {"[info]", "\033[38;5;4m"},
+                 {"[help]", "\033[38;5;5m"},
+                 {"[bold]", "\033[1m"},
+                 {"[nobold]", "\033[22m"},
+                 {"[inverse]", "\033[7m"},
+                 {"[noinverse]", "\033[27m"},
+                 {"[blank]", "\033[0m"}}};
     }
 }

--- a/src/tests/themes.sh
+++ b/src/tests/themes.sh
@@ -17,6 +17,8 @@ CLIPBOARD_THEME=lighthighcontrast cb copy testfile testdir
 
 CLIPBOARD_THEME=darkhighcontrast cb copy testfile testdir
 
+CLIPBOARD_THEME=ansi cb copy testfile testdir
+
 NO_COLOR=1 cb copy testfile testdir
 
 NO_COLOR=1 FORCE_COLOR=1 cb copy testfile testdir


### PR DESCRIPTION
This PR adds a new color which uses the [3-bit ANSI colors](https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit) rather than using the 256-bit colors as in the existing themes. Since Clipboard only has five colors in its output, I was able to stick to just those 3-bit colors and no high-intensity variants.

I would have opened an issue for this, but I checked out the code and it looked so easy to add this that I just went for it. I hope that's ok :slightly_smiling_face:

I named the theme `ansi` because that's what [Bat calls its version of this theme](https://github.com/sharkdp/bat#8-bit-themes).


### Motivation and Demo

The built-in themes weren't enough for me because some of the terminals I use are set to a light theme, and others are set to a dark theme. Unfortunately, the light-friendly themes don't look great when running in a dark terminal and vice versa.

The nice thing about those 3-bit colors is that they're theme-agnostic. Themes are usually designed to have readable colors with good contrast, so command line tools can take advantage of that to output text that is guaranteed to be readable no matter the user's terminal theme preferences. In other words, there's no reason to have separate dark and light variants.

As an example, here's what Clipboard's light theme looks like in my low-saturation, light-themed VSCode terminal:
![Screenshot_20230926_202050](https://github.com/Slackadays/Clipboard/assets/7419746/b3a5e14f-8a2e-4e89-9199-f01c5252164f)

And here it is using the new `ansi` theme:
![Screenshot_20230926_201822](https://github.com/Slackadays/Clipboard/assets/7419746/b0c7fb3b-ab23-44bf-a26a-dcf523447741)

I think the latter fits in much better with the overall vibe, and matches the colors of the prompt and most other colored output.