### PR TITLE
fix(can_use_sudo): We actually look if the actual user can use sudo o…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,15 +53,18 @@ compile() {
 }
 
 can_use_sudo() {
-    # return 0 if sudo isn't available
-    if ! command -v sudo > /dev/null 2>&1
-    then
-        return 0
+    prompt=$(sudo -nv 2>&1)
+    if sudo -nv > /dev/null 2>&1; then
+      # exit code of sudo-command is 0
+      return 0
+    elif echo "$prompt" | grep -q '^sudo:'; then
+      return 0
+    else
+      return 1
     fi
-    # check if we are a sudoer, return 1 if we are
-    sudo -n true 2> /dev/null
-    return $?
 }
+
+printf "\033[32mSearching for a package manager...\n\033[0m"
 
 if command -v apk > /dev/null 2>&1
 then


### PR DESCRIPTION
Hi again,

I install this tool on another system and I still have trouble but this time it was with the **detection of sudo.**
I think this is the best way, the solution is basically [this answer](https://superuser.com/a/1281228) adapted to the script.

Also, unlike other programming languages, for bash **0 is true** and **1 or any other number is false.** I think is like the exit_code, if it is 0 is a successfull exit and if it is any other number it is an error code.

So that's why we need to return 0 when we actually can use sudo and 1 when we can't use it.

Finally, I added a message that we are searching for a package manager, so when the user see the password prompt don't panic.