### PR TITLE
Add automatic confirmation for flatpak

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -95,9 +95,9 @@ elif command -v flatpak > /dev/null 2>&1
 then
     if can_use_sudo
     then
-      sudo flatpak install flathub "$flatpak_package"
+      sudo flatpak install flathub "$flatpak_package" -y
     else
-      flatpak install flathub "$flatpak_package"
+      flatpak install flathub "$flatpak_package" -y
     fi
 
     verify_flatpak
@@ -105,7 +105,7 @@ elif command -v snap > /dev/null 2>&1
 then
     if can_use_sudo
     then
-        sudo snap install clipboard
+        sudo snap install clipboard -y
         verify
     fi
 elif command -v nix-env > /dev/null 2>&1

--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,7 @@ elif command -v snap > /dev/null 2>&1
 then
     if can_use_sudo
     then
-        sudo snap install clipboard -y
+        sudo snap install clipboard
         verify
     fi
 elif command -v nix-env > /dev/null 2>&1


### PR DESCRIPTION
Adding automatic confirmation for flatpak.

On my fedora machine, when the flatpak package "app.getclipboard.Clipboard" installation is starting, the installation led to automatic "n" response, causing the installation to abort.
[Screencast from 2023-10-10 00-09-38.webm](https://github.com/Slackadays/Clipboard/assets/54035934/d65e4851-3952-4666-9794-e68e4adf942a)
```
➜  ~ curl -sSL https://github.com/Slackadays/Clipboard/raw/main/install.sh | sh
Searching for a package manager...
Looking for matches…

app.getclipboard.Clipboard permissions:
    ipc       fallback-x11         pulseaudio      wayland
    x11       file access [1]

    [1] host, xdg-run/Clipboard


        ID                             Branch     Op     Remote      Download
 1.     app.getclipboard.Clipboard     stable     i      flathub     < 1.1 MB

Proceed with these changes to the system installation? [Y/n]: n
```
Automatic confirmation using the -y flag, prevents such interruptions and ensuring a smooth installation process.



