### PR TITLE
Fix package name for Voidlinux in  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ sudo snap install clipboard
 
 **Void Linux**
 ```sh
-sudo xbps-install -S clipboard
+sudo xbps-install -S Clipboard
 ```
 
 <br>


### PR DESCRIPTION
In Voidlinux the package name for clipboard starts with capital C.

![image](https://github.com/Slackadays/Clipboard/assets/58117792/9c9d9e76-6d99-463c-b2dc-ed13c304c81d)

[link to Clipboards template file](https://github.com/void-linux/void-packages/blob/master/srcpkgs/Clipboard/template)