### PR TITLE
build: dont force CMAKE_OSX_ARCHITECTURES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 #make a universal binary on macOS
-set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "" FORCE)
+set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "")
 
 project(Clipboard LANGUAGES CXX C VERSION 0.9.0)
 set(CMAKE_CXX_STANDARD 23)


### PR DESCRIPTION
seeing some build failure while bottling for macos sequoia, but since `CMAKE_OSX_ARCHITECTURES` is forced, there is no way to override it.

relates to https://github.com/Homebrew/homebrew-core/pull/190600