### PR TITLE
Fixed install script, named the required openssl libraries in the README, and fixed a small bug regarding systems without ALSA installed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ $ alias cb='snap run clipboard'
 <br>
 
 ### <img src="documentation/readme-assets/InstallManually.png" alt="Install Manually" height=25px />
-You'll need CMake, C++20 support, and OpenSSL, and if you want X11 or Wayland support, you'll also need libx11 or libwayland plus Wayland Protocols respectively. If you're on Linux, you'll need ALSA.
+You'll need CMake, C++20 support, and OpenSSL(including libssl3 and libssl-dev), and if you want X11 or Wayland support, you'll also need libx11 or libwayland plus Wayland Protocols respectively. If you're on Linux, you'll need ALSA.
 
 Get the latest release instead of the latest commit by adding `--branch 0.9.1` right after `git clone...`.
 

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,142 @@
+#!/bin/sh
+set -eu
+
+unsupported() {
+    printf "\033[31mSorry, but this installer script doesn't support %s.\n\033[0m" "$1"
+    printf '\033[32m💡 However, you can still install CB using the other methods in the readme!\n\033[0m'
+}
+
+verify() {
+    if command -v cb 2>&1
+    then
+        if ! cb 2>&1
+        then
+            unsupported "this system"
+            exit 1
+        else
+            printf "\033[32mClipboard installed successfully!\n\033[0m"
+            exit 0
+        fi
+    else
+        printf "\033[31mCouldn't install CB\n\033[0m"
+        exit 1
+    fi
+}
+
+can_use_sudo() {
+    prompt=$(sudo -nv 2>&1)
+    if sudo -nv > /dev/null 2>&1; then
+      # exit code of sudo-command is 0
+      return 0
+    elif echo "$prompt" | grep -q '^sudo:'; then
+      return 0
+    else
+      return 1
+    fi
+}
+
+tmp_dir=$(mktemp -d -t cb-XXXXXXXXXX)
+cd "$tmp_dir"
+
+if can_use_sudo
+then
+    requires_sudo=true
+    install_path="/usr/local"
+    sudo mkdir -p "$install_path/bin"
+    sudo mkdir -p "$install_path/lib"
+else
+    requires_sudo=false
+    install_path="$HOME/.local"
+    mkdir -p "$install_path/bin"
+    mkdir -p "$install_path/lib"
+fi
+
+if [ "$(uname)" = "Linux" ]
+then
+    if [ "$(uname -m)" = "x86_64" ]
+    then
+        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-amd64.zip
+    elif [ "$(uname -m)" = "aarch64" ]
+    then
+        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-arm64.zip
+    elif [ "$(uname -m)" = "riscv64" ]
+    then
+        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-riscv64.zip
+    elif [ "$(uname -m)" = "i386" ]
+    then
+        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-i386.zip
+    elif [ "$(uname -m)" = "ppc64le" ]
+    then
+        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-ppc64le.zip
+    elif [ "$(uname -m)" = "s390x" ]
+    then
+        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-s390x.zip
+    else
+        download_link="skip"
+    fi
+    if [ "$download_link" != "skip" ]
+    then
+        curl -SL $download_link -o clipboard-linux.zip
+        unzip clipboard-linux.zip
+        rm clipboard-linux.zip
+        if [ "$requires_sudo" = true ]
+        then
+            sudo mv bin/cb "$install_path/bin/cb"
+        else
+            mv bin/cb "$install_path/bin/cb"
+        fi
+        chmod +x "$install_path/bin/cb"
+        if [ -f "lib/libcbx11.so" ]
+        then
+            if [ "$requires_sudo" = true ]
+            then
+                sudo mv lib/libcbx11.so "$install_path/lib/libcbx11.so"
+            else
+                mv lib/libcbx11.so "$install_path/lib/libcbx11.so"
+            fi
+        fi
+        if [ -f "lib/libcbwayland.so" ]
+        then
+            if [ "$requires_sudo" = true ]
+            then
+                sudo mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
+            else
+                mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
+            fi
+        fi
+    fi
+elif [ "$(uname)" = "Darwin" ]
+then
+    if [ "$(uname -m)" = "x86_64" ]
+    then
+        curl -SsLl https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-macos-amd64.zip -o clipboard-macos.zip
+    elif [ "$(uname -m)" = "arm64" ]
+    then
+        curl -SsLl https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-macos-arm64.zip -o clipboard-macos.zip
+    fi
+    unzip clipboard-macos.zip
+    rm clipboard-macos.zip
+    sudo mv bin/cb "$install_path/bin/cb"
+    chmod +x "$install_path/bin/cb"
+elif [ "$(uname)" = "FreeBSD" ]
+then
+    unsupported "FreeBSD"
+    exit 0
+elif [ "$(uname)" = "OpenBSD" ]
+then
+    unsupported "OpenBSD"
+    exit 0
+elif [ "$(uname)" = "NetBSD" ]
+then
+    unsupported "NetBSD"
+    exit 0
+else
+    unsupported "$(uname)"
+    exit 0
+fi
+
+cd ..
+
+rm -rf "$tmp_dir"
+
+verify

--- a/install.sh
+++ b/install.sh
@@ -37,21 +37,6 @@ verify() {
     fi
 }
 
-compile() {
-    git clone --depth 1 https://github.com/slackadays/Clipboard
-    cd Clipboard/build
-    cmake ..
-    cmake --build .
-    cmake --install .
-
-    if [ "$(uname)" = "OpenBSD" ] #check if OpenBSD
-    then
-        doas cmake --install .
-    else
-        sudo cmake --install .
-    fi
-}
-
 can_use_sudo() {
     prompt=$(sudo -nv 2>&1)
     if sudo -nv > /dev/null 2>&1; then
@@ -63,6 +48,39 @@ can_use_sudo() {
       return 1
     fi
 }
+
+has_alsa(){
+    if command -v aplay >/dev/null 2>&1 && [ -d "/dev/snd" ]; then
+      return 1 
+    else
+      return 0
+   fi 
+}
+
+compile() {
+    git clone --depth 1 https://github.com/slackadays/Clipboard
+    cd Clipboard/build
+    
+    if has_alsa
+    then
+      cmake ..
+    else
+      cmake -DNO_ALSA=true ..
+    fi
+
+    cmake --build . 
+
+    if [ "$(uname)" = "OpenBSD" ] #check if OpenBSD
+    then
+        doas cmake --install .
+    elif can_use_sudo
+    then
+        sudo cmake --install .
+    else
+        cmake --install .
+    fi
+}
+
 
 printf "\033[32mSearching for a package manager...\n\033[0m"
 
@@ -87,10 +105,6 @@ then
         sudo emerge -av app-misc/clipboard
         verify
     fi
-elif command -v brew > /dev/null 2>&1
-then
-    brew install clipboard
-    verify
 elif command -v flatpak > /dev/null 2>&1
 then
     if can_use_sudo
@@ -127,109 +141,14 @@ then
         sudo xbps-install -S clipboard
         verify
     fi
-fi
-
-tmp_dir=$(mktemp -d -t cb-XXXXXXXXXX)
-cd "$tmp_dir"
-
-if can_use_sudo
-then
-    requires_sudo=true
-    install_path="/usr/local"
-    sudo mkdir -p "$install_path/bin"
-    sudo mkdir -p "$install_path/lib"
 else
-    requires_sudo=false
-    install_path="$HOME/.local"
-    mkdir -p "$install_path/bin"
-    mkdir -p "$install_path/lib"
-fi
-
-if [ "$(uname)" = "Linux" ]
-then
-    if [ "$(uname -m)" = "x86_64" ]
-    then
-        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-amd64.zip
-    elif [ "$(uname -m)" = "aarch64" ]
-    then
-        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-arm64.zip
-    elif [ "$(uname -m)" = "riscv64" ]
-    then
-        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-riscv64.zip
-    elif [ "$(uname -m)" = "i386" ]
-    then
-        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-i386.zip
-    elif [ "$(uname -m)" = "ppc64le" ]
-    then
-        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-ppc64le.zip
-    elif [ "$(uname -m)" = "s390x" ]
-    then
-        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-s390x.zip
-    else
-        download_link="skip"
-    fi
-    if [ "$download_link" != "skip" ]
-    then
-        curl -SL $download_link -o clipboard-linux.zip
-        unzip clipboard-linux.zip
-        rm clipboard-linux.zip
-        if [ "$requires_sudo" = true ]
-        then
-            sudo mv bin/cb "$install_path/bin/cb"
-        else
-            mv bin/cb "$install_path/bin/cb"
-        fi
-        chmod +x "$install_path/bin/cb"
-        if [ -f "lib/libcbx11.so" ]
-        then
-            if [ "$requires_sudo" = true ]
-            then
-                sudo mv lib/libcbx11.so "$install_path/lib/libcbx11.so"
-            else
-                mv lib/libcbx11.so "$install_path/lib/libcbx11.so"
-            fi
-        fi
-        if [ -f "lib/libcbwayland.so" ]
-        then
-            if [ "$requires_sudo" = true ]
-            then
-                sudo mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
-            else
-                mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
-            fi
-        fi
-    fi
-elif [ "$(uname)" = "Darwin" ]
-then
-    if [ "$(uname -m)" = "x86_64" ]
-    then
-        curl -SsLl https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-macos-amd64.zip -o clipboard-macos.zip
-    elif [ "$(uname -m)" = "arm64" ]
-    then
-        curl -SsLl https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-macos-arm64.zip -o clipboard-macos.zip
-    fi
-    unzip clipboard-macos.zip
-    rm clipboard-macos.zip
-    sudo mv bin/cb "$install_path/bin/cb"
-    chmod +x "$install_path/bin/cb"
-elif [ "$(uname)" = "FreeBSD" ]
-then
-    unsupported "FreeBSD"
-    exit 0
-elif [ "$(uname)" = "OpenBSD" ]
-then
-    unsupported "OpenBSD"
-    exit 0
-elif [ "$(uname)" = "NetBSD" ]
-then
-    unsupported "NetBSD"
-    exit 0
-else
-compile
+##TODO: If the download links are updated, I left the rest of the script in ./download.sh and this should work##
+# cd ..
+# sh ./download.sh
+printf "\033[32mNot found in package manager, compiling with cmake...\n\033[0m"
+    compile
 fi
 
 cd ..
-
-rm -rf "$tmp_dir"
 
 verify

--- a/src/cb/src/platforms/linux.cpp
+++ b/src/cb/src/platforms/linux.cpp
@@ -14,8 +14,10 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 #include "../clipboard.hpp"
-#include <alsa/asoundlib.h>
 
+#if defined(USE_ALSA)
+#include <alsa/asoundlib.h>
+#endif
 void dummy_handler(const char* file, int line, const char* function, int err, const char* fmt, ...) {}
 
 bool playAsyncSoundEffect(const std::valarray<short>& samples) {


### PR DESCRIPTION
I separated the bug fix and README edit from the install script changes because they are more minor changes.  I just added two lines around #include<alsa/asoundlib.h> that check for USE_ALSA, just like the function below it.  The README just contains the specific packages needed, because the openssl package does not include the -dev package needed for includes.

As for the install.sh script, I broke it into two parts, install checks if it can be installed with a package manager, and if not, it just calls the compile script rather than using the downloads.  I put the second part of the script in download.sh, and commented out calling sh ./download.sh, so if the links are fixed, the install script would work the same way as before.

The compile() function also did not work on my machine without `sudo cmake --install .` , so I just moved that part below where it checks for OpenBSD, and added `else sudo cmake --install . fi`, so it doesn't attempt to use install without sudo and fail the build before the check.

The changes could definitely be improved, (like checking if sudo is needed in that last example), but it makes the install script functional again for distributions which use the APT package manager, which is a lot of distributions.
