### PR TITLE
Fixed build errors on linux platform with no alsa, added required openssl libraries to readme, and modified the install.sh not to use the dead links.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,8 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  if (NOT NO_ALSA)
+  if(USE_ALSA)
     find_package(ALSA REQUIRED)
-    add_definitions(-DUSE_ALSA)
   endif()
   #find_path(LIBURING_INCLUDE_DIR liburing.h)
   #if (LIBURING_INCLUDE_DIR)
@@ -50,6 +49,10 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   #else()
   #  message(FATAL_ERROR "Could not find liburing")
   #endif()
+
+  #If the system were not Linux, but -DUSE_ALSA was passed, unset it
+elseif(USE_ALSA)
+  unset(USE_ALSA)
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -96,14 +99,14 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL ${LIB_LOCATION})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${BIN_LOCATION})
 
 function(enable_lto this_target)
-include(CheckIPOSupported)
-check_ipo_supported(RESULT lto_supported)
-if(lto_supported AND NOT NO_LTO)
-  set_property(TARGET ${this_target} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
-  if(CMAKE_COMPILER_IS_GNUCXX)
-    list(APPEND CMAKE_CXX_COMPILE_OPTIONS_IPO "-flto=auto") # set the thread amount to what is available on the CPU
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT lto_supported)
+  if(lto_supported AND NOT NO_LTO)
+    set_property(TARGET ${this_target} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+    if(CMAKE_COMPILER_IS_GNUCXX)
+      list(APPEND CMAKE_CXX_COMPILE_OPTIONS_IPO "-flto=auto") # set the thread amount to what is available on the CPU
+    endif()
   endif()
-endif()
 endfunction()
 
 add_subdirectory(src/gui)

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ $ alias cb='snap run clipboard'
 <br>
 
 ### <img src="documentation/readme-assets/InstallManually.png" alt="Install Manually" height=25px />
-You'll need CMake, C++20 support, and OpenSSL, and if you want X11 or Wayland support, you'll also need libx11 or libwayland plus Wayland Protocols respectively. If you're on Linux, you'll need ALSA.
+You'll need CMake, C++20 support, and OpenSSL(including libssl3 and libssl-dev), and if you want X11 or Wayland support, you'll also need libx11 or libwayland plus Wayland Protocols respectively. If you're on Linux, you'll need ALSA.
 
 Get the latest release instead of the latest commit by adding `--branch 0.9.1` right after `git clone...`.
 

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,142 @@
+#!/bin/sh
+set -eu
+
+unsupported() {
+    printf "\033[31mSorry, but this installer script doesn't support %s.\n\033[0m" "$1"
+    printf '\033[32m💡 However, you can still install CB using the other methods in the readme!\n\033[0m'
+}
+
+verify() {
+    if command -v cb 2>&1
+    then
+        if ! cb 2>&1
+        then
+            unsupported "this system"
+            exit 1
+        else
+            printf "\033[32mClipboard installed successfully!\n\033[0m"
+            exit 0
+        fi
+    else
+        printf "\033[31mCouldn't install CB\n\033[0m"
+        exit 1
+    fi
+}
+
+can_use_sudo() {
+    prompt=$(sudo -nv 2>&1)
+    if sudo -nv > /dev/null 2>&1; then
+      # exit code of sudo-command is 0
+      return 0
+    elif echo "$prompt" | grep -q '^sudo:'; then
+      return 0
+    else
+      return 1
+    fi
+}
+
+tmp_dir=$(mktemp -d -t cb-XXXXXXXXXX)
+cd "$tmp_dir"
+
+if can_use_sudo
+then
+    requires_sudo=true
+    install_path="/usr/local"
+    sudo mkdir -p "$install_path/bin"
+    sudo mkdir -p "$install_path/lib"
+else
+    requires_sudo=false
+    install_path="$HOME/.local"
+    mkdir -p "$install_path/bin"
+    mkdir -p "$install_path/lib"
+fi
+
+if [ "$(uname)" = "Linux" ]
+then
+    if [ "$(uname -m)" = "x86_64" ]
+    then
+        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-amd64.zip
+    elif [ "$(uname -m)" = "aarch64" ]
+    then
+        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-arm64.zip
+    elif [ "$(uname -m)" = "riscv64" ]
+    then
+        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-riscv64.zip
+    elif [ "$(uname -m)" = "i386" ]
+    then
+        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-i386.zip
+    elif [ "$(uname -m)" = "ppc64le" ]
+    then
+        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-ppc64le.zip
+    elif [ "$(uname -m)" = "s390x" ]
+    then
+        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-s390x.zip
+    else
+        download_link="skip"
+    fi
+    if [ "$download_link" != "skip" ]
+    then
+        curl -SL $download_link -o clipboard-linux.zip
+        unzip clipboard-linux.zip
+        rm clipboard-linux.zip
+        if [ "$requires_sudo" = true ]
+        then
+            sudo mv bin/cb "$install_path/bin/cb"
+        else
+            mv bin/cb "$install_path/bin/cb"
+        fi
+        chmod +x "$install_path/bin/cb"
+        if [ -f "lib/libcbx11.so" ]
+        then
+            if [ "$requires_sudo" = true ]
+            then
+                sudo mv lib/libcbx11.so "$install_path/lib/libcbx11.so"
+            else
+                mv lib/libcbx11.so "$install_path/lib/libcbx11.so"
+            fi
+        fi
+        if [ -f "lib/libcbwayland.so" ]
+        then
+            if [ "$requires_sudo" = true ]
+            then
+                sudo mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
+            else
+                mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
+            fi
+        fi
+    fi
+elif [ "$(uname)" = "Darwin" ]
+then
+    if [ "$(uname -m)" = "x86_64" ]
+    then
+        curl -SsLl https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-macos-amd64.zip -o clipboard-macos.zip
+    elif [ "$(uname -m)" = "arm64" ]
+    then
+        curl -SsLl https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-macos-arm64.zip -o clipboard-macos.zip
+    fi
+    unzip clipboard-macos.zip
+    rm clipboard-macos.zip
+    sudo mv bin/cb "$install_path/bin/cb"
+    chmod +x "$install_path/bin/cb"
+elif [ "$(uname)" = "FreeBSD" ]
+then
+    unsupported "FreeBSD"
+    exit 0
+elif [ "$(uname)" = "OpenBSD" ]
+then
+    unsupported "OpenBSD"
+    exit 0
+elif [ "$(uname)" = "NetBSD" ]
+then
+    unsupported "NetBSD"
+    exit 0
+else
+    unsupported "$(uname)"
+    exit 0
+fi
+
+cd ..
+
+rm -rf "$tmp_dir"
+
+verify

--- a/install.sh
+++ b/install.sh
@@ -37,21 +37,6 @@ verify() {
     fi
 }
 
-compile() {
-    git clone --depth 1 https://github.com/slackadays/Clipboard
-    cd Clipboard/build
-    cmake ..
-    cmake --build .
-    cmake --install .
-
-    if [ "$(uname)" = "OpenBSD" ] #check if OpenBSD
-    then
-        doas cmake --install .
-    else
-        sudo cmake --install .
-    fi
-}
-
 can_use_sudo() {
     prompt=$(sudo -nv 2>&1)
     if sudo -nv > /dev/null 2>&1; then
@@ -63,6 +48,25 @@ can_use_sudo() {
       return 1
     fi
 }
+
+compile() {
+    git clone --depth 1 https://github.com/slackadays/Clipboard
+    cd Clipboard/build
+    
+    cmake ..
+    cmake --build . 
+
+    if [ "$(uname)" = "OpenBSD" ] #check if OpenBSD
+    then
+        doas cmake --install .
+    elif can_use_sudo
+    then
+        sudo cmake --install .
+    else
+        cmake --install .
+    fi
+}
+
 
 printf "\033[32mSearching for a package manager...\n\033[0m"
 
@@ -87,10 +91,6 @@ then
         sudo emerge -av app-misc/clipboard
         verify
     fi
-elif command -v brew > /dev/null 2>&1
-then
-    brew install clipboard
-    verify
 elif command -v flatpak > /dev/null 2>&1
 then
     if can_use_sudo
@@ -127,109 +127,13 @@ then
         sudo xbps-install -S clipboard
         verify
     fi
-fi
-
-tmp_dir=$(mktemp -d -t cb-XXXXXXXXXX)
-cd "$tmp_dir"
-
-if can_use_sudo
-then
-    requires_sudo=true
-    install_path="/usr/local"
-    sudo mkdir -p "$install_path/bin"
-    sudo mkdir -p "$install_path/lib"
 else
-    requires_sudo=false
-    install_path="$HOME/.local"
-    mkdir -p "$install_path/bin"
-    mkdir -p "$install_path/lib"
+##TODO: If the download links are updated, I left the rest of the script in ./download.sh and this should work##
+# cd ..
+# sh ./download.sh
+printf "\033[32mNot found in package manager, compiling with cmake...\n\033[0m"
+    compile
 fi
 
-if [ "$(uname)" = "Linux" ]
-then
-    if [ "$(uname -m)" = "x86_64" ]
-    then
-        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-amd64.zip
-    elif [ "$(uname -m)" = "aarch64" ]
-    then
-        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-arm64.zip
-    elif [ "$(uname -m)" = "riscv64" ]
-    then
-        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-riscv64.zip
-    elif [ "$(uname -m)" = "i386" ]
-    then
-        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-i386.zip
-    elif [ "$(uname -m)" = "ppc64le" ]
-    then
-        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-ppc64le.zip
-    elif [ "$(uname -m)" = "s390x" ]
-    then
-        download_link=https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-linux-s390x.zip
-    else
-        download_link="skip"
-    fi
-    if [ "$download_link" != "skip" ]
-    then
-        curl -SL $download_link -o clipboard-linux.zip
-        unzip clipboard-linux.zip
-        rm clipboard-linux.zip
-        if [ "$requires_sudo" = true ]
-        then
-            sudo mv bin/cb "$install_path/bin/cb"
-        else
-            mv bin/cb "$install_path/bin/cb"
-        fi
-        chmod +x "$install_path/bin/cb"
-        if [ -f "lib/libcbx11.so" ]
-        then
-            if [ "$requires_sudo" = true ]
-            then
-                sudo mv lib/libcbx11.so "$install_path/lib/libcbx11.so"
-            else
-                mv lib/libcbx11.so "$install_path/lib/libcbx11.so"
-            fi
-        fi
-        if [ -f "lib/libcbwayland.so" ]
-        then
-            if [ "$requires_sudo" = true ]
-            then
-                sudo mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
-            else
-                mv lib/libcbwayland.so "$install_path/lib/libcbwayland.so"
-            fi
-        fi
-    fi
-elif [ "$(uname)" = "Darwin" ]
-then
-    if [ "$(uname -m)" = "x86_64" ]
-    then
-        curl -SsLl https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-macos-amd64.zip -o clipboard-macos.zip
-    elif [ "$(uname -m)" = "arm64" ]
-    then
-        curl -SsLl https://nightly.link/Slackadays/Clipboard/workflows/build-clipboard/main/clipboard-macos-arm64.zip -o clipboard-macos.zip
-    fi
-    unzip clipboard-macos.zip
-    rm clipboard-macos.zip
-    sudo mv bin/cb "$install_path/bin/cb"
-    chmod +x "$install_path/bin/cb"
-elif [ "$(uname)" = "FreeBSD" ]
-then
-    unsupported "FreeBSD"
-    exit 0
-elif [ "$(uname)" = "OpenBSD" ]
-then
-    unsupported "OpenBSD"
-    exit 0
-elif [ "$(uname)" = "NetBSD" ]
-then
-    unsupported "NetBSD"
-    exit 0
-else
-compile
-fi
-
-cd ..
-
-rm -rf "$tmp_dir"
 
 verify

--- a/src/cb/src/platforms/linux.cpp
+++ b/src/cb/src/platforms/linux.cpp
@@ -14,8 +14,10 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 #include "../clipboard.hpp"
-#include <alsa/asoundlib.h>
 
+#if defined(USE_ALSA)
+#include <alsa/asoundlib.h>
+#endif
 void dummy_handler(const char* file, int line, const char* function, int err, const char* fmt, ...) {}
 
 bool playAsyncSoundEffect(const std::valarray<short>& samples) {


### PR DESCRIPTION
Squashed my first pull request to keep tree tidy, and used clang-format on the small bit of code I changed.
Modified install script to either use a package manager, or compile with cmake, due to the broken links.
Added 'has_alsa' check, and calls cmake with -DNO_ALSA=true if alsa does not exist
