### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1271,7 +1271,7 @@ $ cb --clipboard 10 copy BarBaz
 
 Copy to a temporary clipboard that doesn't start with a number.
 ```sh
-$ cb -c SomeCB copy "A really really long sentence, and I mean really realy super DUPER long!"
+$ cb -c SomeCB copy "A really really long sentence, and I mean really really super DUPER long!"
 ```
 
 Note: Although copying to a temporary clipboard that doesn't start with a number is impossible using the conventional method of adding it to the end of the action, this alternative method is completely supported and works great.

--- a/documentation/website/content/_docs.md
+++ b/documentation/website/content/_docs.md
@@ -860,7 +860,7 @@ $ cb --clipboard 10 copy BarBaz
 
 Copy to a temporary clipboard that doesn't start with a number.
 ```sh
-$ cb -c SomeCB copy "A really really long sentence, and I mean really realy super DUPER long!"
+$ cb -c SomeCB copy "A really really long sentence, and I mean really really super DUPER long!"
 ```
 
 Note: Although copying to a temporary clipboard that doesn't start with a number is impossible using the conventional method of adding it to the end of the action, this alternative method is completely supported and works great.

--- a/src/cb/src/utils/formatting.cpp
+++ b/src/cb/src/utils/formatting.cpp
@@ -68,7 +68,7 @@ std::string makeControlCharactersVisible(const std::string_view& oldStr, size_t 
 
     if (len == 0) len = oldStr.size();
 
-    // format characters such as \n and \r such that they appear as \n and \r surrounded by lightening terminal colors
+    // format characters such as \n and \r such that they appear as \n and \r surrounded by lightning terminal colors
     const std::array<std::pair<char, std::string_view>, 8> replacementCharacters {
             {{'\n', "\\n"}, {'\r', "\\r"}, {'\a', "\\a"}, {'\b', "\\b"}, {'\f', "\\f"}, {'\t', "\\t"}, {'\v', "\\v"}, {'\0', "\\0"}}};
 

--- a/src/cb/src/utils/utils.cpp
+++ b/src/cb/src/utils/utils.cpp
@@ -250,7 +250,7 @@ void setupHandlers() {
     auto exitCleanly = [](int) {
         fprintf(stderr, "%s", formatColors("[blank]").data());
         if (!stopIndicator(false)) {
-            // Indicator thread is not currently running. TODO: Write an unbuffered newline, and maybe a cancelation
+            // Indicator thread is not currently running. TODO: Write an unbuffered newline, and maybe a cancellation
             // message, directly to standard error. Note: There is no standard C++ interface for this, so this requires
             // an OS call.
             path.releaseLock();


### PR DESCRIPTION
Found via `codespell -S ./src/cb/src/locales,*.svg -L splitted,requestor,delet,caf,daa,sav`

