### PR TITLE
Fix macOS multi-file copy to clipboard (#234)

### DIFF
--- a/src/cb/src/externalclipboards.cpp
+++ b/src/cb/src/externalclipboards.cpp
@@ -256,6 +256,15 @@ void syncWithExternalClipboards(bool force) {
         ClipboardContent content;
         if (!envVarIsTrue("CLIPBOARD_NOREMOTE")) content = getRemoteClipboard();
         if (content.type() == Empty && !envVarIsTrue("CLIPBOARD_NOGUI")) content = getGUIClipboard(preferred_mime);
+        // For non-write actions (Paste, Show, etc.), don't write GUI clipboard content
+        // into internal storage. On macOS, other apps (e.g. terminal) may overwrite
+        // the system clipboard between copy and paste, and writing that stale/wrong
+        // content as a new entry would break the paste operation.
+        // See https://github.com/Slackadays/Clipboard/issues/234
+        if (!isAWriteAction() && !force) {
+            available_mimes = content.availableTypes();
+            return;
+        }
         if (content.type() == Text) {
             convertFromGUIClipboard(content.text());
             copying.mime = !content.mime().empty() ? content.mime() : inferMIMEType(content.text()).value_or("text/plain");

--- a/src/cb/src/platforms/macos.mm
+++ b/src/cb/src/platforms/macos.mm
@@ -65,15 +65,14 @@ void writeToGUIClipboard(const ClipboardContent& clipboard) {
     if (clipboard.type() == ClipboardContentType::Text || clipboard.type() == ClipboardContentType::Binary) {
         [[NSPasteboard generalPasteboard] setString:@(clipboard.text().c_str()) forType:NSPasteboardTypeString];
     } else if (clipboard.type() == ClipboardContentType::Paths) {
-        NSMutableArray *fileArray = [NSMutableArray new];
+        NSMutableArray *items = [NSMutableArray new];
         for (auto const& path : clipboard.paths().paths()) {
-            [fileArray addObject:[NSURL fileURLWithPath:@(path.c_str())]];
+            NSURL *url = [NSURL fileURLWithPath:@(path.c_str())];
+            NSPasteboardItem *item = [[NSPasteboardItem alloc] init];
+            [item setString:url.absoluteString forType:NSPasteboardTypeFileURL];
+            [items addObject:item];
         }
-        [[NSPasteboard generalPasteboard] writeObjects:fileArray];
-        // Workaround for a macOS bug: after writing multiple items to the
-        // pasteboard, only the last one may persist unless we read them back.
-        // See https://github.com/Slackadays/Clipboard/issues/234
-        [[NSPasteboard generalPasteboard] readObjectsForClasses:@[ [NSURL class] ] options:nil];
+        [[NSPasteboard generalPasteboard] writeObjects:items];
     } else {
         // Write blank content
         [[NSPasteboard generalPasteboard] setString:@"" forType:NSPasteboardTypeString];

--- a/src/cb/src/platforms/macos.mm
+++ b/src/cb/src/platforms/macos.mm
@@ -70,6 +70,10 @@ void writeToGUIClipboard(const ClipboardContent& clipboard) {
             [fileArray addObject:[NSURL fileURLWithPath:@(path.c_str())]];
         }
         [[NSPasteboard generalPasteboard] writeObjects:fileArray];
+        // Workaround for a macOS bug: after writing multiple items to the
+        // pasteboard, only the last one may persist unless we read them back.
+        // See https://github.com/Slackadays/Clipboard/issues/234
+        [[NSPasteboard generalPasteboard] readObjectsForClasses:@[ [NSURL class] ] options:nil];
     } else {
         // Write blank content
         [[NSPasteboard generalPasteboard] setString:@"" forType:NSPasteboardTypeString];


### PR DESCRIPTION
## Summary
- Fix inability to copy multiple files to clipboard on macOS by reading back from NSPasteboard after writing (#234)
- Fix `cb paste` outputting text instead of files when external apps overwrite the system clipboard between copy and paste

## Problem 1: Multiple files not preserved on macOS
macOS has a bug where `NSPasteboard.writeObjects:` only retains the last item when writing multiple file URLs. This caused `cb copy file1 file2 file3` to only preserve one file on the system clipboard.

Fix: Read back from the pasteboard immediately after writing with `readObjectsForClasses:`, which forces macOS to internalize all written items.

The fix is based on a workaround shared by [timhansinger](https://github.com/timhansinger) in [#234](https://github.com/Slackadays/Clipboard/issues/234), who encountered the same macOS pasteboard bug in their own tool [pbcp](https://github.com/timhansinger/pbcp) and solved it with the same read-back approach (implemented in Swift). The technique translates directly to our Objective-C++ code since both use the same `NSPasteboard` API.

## Problem 2: `cb paste` outputs text instead of files
While testing Problem 1 over SSH, we discovered that `cb paste` would output shell command text (from the terminal's OSC 52 response) instead of the copied files. The root cause: `syncWithExternalClipboards()` was called at the start of every `cb` invocation, including paste/show. It would read whatever was on the system clipboard (which other apps like the terminal may have overwritten) and write it as a new clipboard entry via `convertFromGUIClipboard()`, effectively replacing the file entry with a text entry.

Fix: Skip calling `convertFromGUIClipboard()` for non-write actions (paste, show, etc.) since these operations should only read from internal storage, not ingest whatever is currently on the system clipboard.