### PR TITLE
Fix leaked DIR* handle in generatedEntryIndex()

### DIFF
--- a/src/cb/src/clipboard.cpp
+++ b/src/cb/src/clipboard.cpp
@@ -15,6 +15,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 #include "clipboard.hpp"
 #include <charconv>
+#include <memory>
 #include <openssl/sha.h>
 
 Clipboard::Clipboard(const std::string& clipboard_name, const unsigned long& clipboard_entry) {
@@ -64,6 +65,12 @@ std::deque<unsigned long> Clipboard::generatedEntryIndex() {
     fs::create_directories(entriesDir);
 #if defined(UNIX_OR_UNIX_LIKE)
     auto dirptr = opendir(entriesDir.string().data());
+    if (!dirptr) {
+        if (pathNames.empty()) pathNames.emplace_back(0);
+        std::sort(pathNames.begin(), pathNames.end(), std::greater<>());
+        return pathNames;
+    }
+    std::unique_ptr<DIR, decltype(&closedir)> dir_guard(dirptr, &closedir);
     errno = 0;
     for (auto* dir = readdir(dirptr); dir != nullptr; dir = readdir(dirptr), errno = 0) {
         pathNames.emplace_back(0);


### PR DESCRIPTION
## Summary

Fixes a file descriptor leak in `Clipboard::generatedEntryIndex()` where the `DIR*` returned by `opendir()` was never passed to `closedir()`.

## Changes

- Added null check for `opendir()` return value with early return
- Wrapped `dirptr` in `std::unique_ptr<DIR, decltype(&closedir)>` for RAII cleanup
- Added `#include <memory>`

## Impact

This leak occurred on every clipboard operation that called `generatedEntryIndex()` (essentially every invocation on Unix-like systems). Over time, repeated use could exhaust available file descriptors.